### PR TITLE
Fix user creation race condition

### DIFF
--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -21,7 +21,7 @@ from services.subscription_service import SubscriptionService
 from services.mission_service import MissionService
 from services.achievement_service import AchievementService
 from database.models import User, UserBadge, set_user_menu_state
-from utils.text_utils import sanitize_text
+from utils.user_utils import get_or_create_user
 
 router = Router()
 
@@ -211,14 +211,13 @@ async def game_profile(callback: CallbackQuery, session: AsyncSession):
     user_id = callback.from_user.id
     user: User | None = await session.get(User, user_id)
     if not user:
-        user = User(
-            id=user_id,
-            username=sanitize_text(callback.from_user.username),
-            first_name=sanitize_text(callback.from_user.first_name),
-            last_name=sanitize_text(callback.from_user.last_name),
+        user = await get_or_create_user(
+            session,
+            user_id,
+            username=callback.from_user.username,
+            first_name=callback.from_user.first_name,
+            last_name=callback.from_user.last_name,
         )
-        session.add(user)
-        await session.commit()
 
     mission_service = MissionService(session)
     active_missions = await mission_service.get_active_missions(user_id=user_id)

--- a/mybot/middlewares/points_middleware.py
+++ b/mybot/middlewares/points_middleware.py
@@ -6,6 +6,7 @@ except ImportError:  # Fallback for older aiogram
     MessageReactionUpdated = object
 from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import User
+from utils.user_utils import get_or_create_user
 from services.point_service import PointService
 from utils.messages import BOT_MESSAGES
 import logging
@@ -56,9 +57,7 @@ class PointsMiddleware(BaseMiddleware):
                 if user_id and message_id:
                     user = await session.get(User, user_id)
                     if not user:
-                        user = User(id=user_id)
-                        session.add(user)
-                        await session.commit()
+                        user = await get_or_create_user(session, user_id)
                     await service.award_reaction(user, message_id, bot)
                     await mission_service.update_progress(user_id, "reaction", bot=bot)
                     await bot.send_message(user_id, BOT_MESSAGES["reaction_registered"])

--- a/mybot/services/point_service.py
+++ b/mybot/services/point_service.py
@@ -1,6 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from database.models import User, UserProgress
+from utils.user_utils import get_or_create_user
 from utils.user_roles import get_points_multiplier
 from aiogram import Bot
 from services.level_service import LevelService
@@ -107,10 +108,7 @@ class PointService:
             logger.warning(
                 f"Attempted to add points to non-existent user {user_id}. Creating new user."
             )
-            user = User(id=user_id, points=0)
-            self.session.add(user)
-            await self.session.commit()
-            await self.session.refresh(user)
+            user = await get_or_create_user(self.session, user_id)
 
         multiplier = 1
         if bot:

--- a/mybot/services/tenant_service.py
+++ b/mybot/services/tenant_service.py
@@ -7,6 +7,7 @@ from typing import Optional, Dict, Any
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from database.models import ConfigEntry, User, Tariff
+from utils.user_utils import get_or_create_user
 from services.config_service import ConfigService
 from services.channel_service import ChannelService
 from utils.text_utils import sanitize_text
@@ -35,11 +36,11 @@ class TenantService:
             # Ensure user exists and is marked as admin
             user = await self.session.get(User, admin_user_id)
             if not user:
-                user = User(id=admin_user_id, role="admin")
-                self.session.add(user)
-            else:
-                user.role = "admin"
-            
+                user = await get_or_create_user(
+                    self.session,
+                    admin_user_id,
+                )
+            user.role = "admin"
             await self.session.commit()
             
             # Check if tenant is already configured

--- a/mybot/utils/user_utils.py
+++ b/mybot/utils/user_utils.py
@@ -1,0 +1,36 @@
+import logging
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError
+from database.models import User
+from .text_utils import sanitize_text
+
+logger = logging.getLogger(__name__)
+
+async def get_or_create_user(
+    session: AsyncSession,
+    user_id: int,
+    *,
+    username: str | None = None,
+    first_name: str | None = None,
+    last_name: str | None = None,
+) -> User:
+    """Return existing user or create a new one safely."""
+    user = await session.get(User, user_id)
+    if user:
+        return user
+
+    user = User(
+        id=user_id,
+        username=sanitize_text(username),
+        first_name=sanitize_text(first_name),
+        last_name=sanitize_text(last_name),
+    )
+    session.add(user)
+    try:
+        await session.commit()
+        await session.refresh(user)
+        logger.info("Created new user: %s", user_id)
+    except IntegrityError:
+        await session.rollback()
+        user = await session.get(User, user_id)
+    return user


### PR DESCRIPTION
## Summary
- add `get_or_create_user` helper for safe user creation
- use helper throughout handlers and services
- remove unused imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852bca3fecc8329a459b0db00abef67