### PR TITLE
Fix admin role check in guided setup buttons

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -51,7 +51,7 @@ async def admin_start(message: Message, session: AsyncSession):
     if not tenant_status["basic_setup_complete"]:
         # Redirect to setup
         from handlers.setup import start_setup
-        await start_setup(message, session)
+        await start_setup(message, session, user_id=message.from_user.id)
         return
     
     # Show admin panel
@@ -59,9 +59,10 @@ async def admin_start(message: Message, session: AsyncSession):
     await menu_manager.show_menu(message, text, keyboard, session, "admin_main")
 
 @router.message(Command("admin_menu"))
-async def admin_menu(message: Message, session: AsyncSession):
+async def admin_menu(message: Message, session: AsyncSession, user_id: int | None = None):
     """Enhanced admin menu command."""
-    if not is_admin(message.from_user.id):
+    uid = user_id if user_id is not None else message.from_user.id
+    if not is_admin(uid):
         await menu_manager.send_temporary_message(
             message,
             "❌ **Acceso Denegado**\n\nNo tienes permisos de administrador.",
@@ -70,10 +71,10 @@ async def admin_menu(message: Message, session: AsyncSession):
         return
     
     try:
-        text, keyboard = await menu_factory.create_menu("admin_main", message.from_user.id, session, message.bot)
+        text, keyboard = await menu_factory.create_menu("admin_main", uid, session, message.bot)
         await menu_manager.show_menu(message, text, keyboard, session, "admin_main")
     except Exception as e:
-        logger.error(f"Error showing admin menu for user {message.from_user.id}: {e}")
+        logger.error(f"Error showing admin menu for user {uid}: {e}")
         await menu_manager.send_temporary_message(
             message,
             "❌ **Error Temporal**\n\nNo se pudo cargar el panel de administración.",

--- a/mybot/handlers/setup.py
+++ b/mybot/handlers/setup.py
@@ -37,18 +37,19 @@ class SetupStates(StatesGroup):
     configuring_gamification = State()
 
 @router.message(Command("setup"))
-async def start_setup(message: Message, session: AsyncSession):
+async def start_setup(message: Message, session: AsyncSession, user_id: int | None = None):
     """Start the initial setup process for new admins."""
-    if not is_admin(message.from_user.id):
+    uid = user_id if user_id is not None else message.from_user.id
+    if not is_admin(uid):
         await menu_manager.send_temporary_message(
             message,
             "❌ **Acceso Denegado**\n\nSolo los administradores pueden acceder a la configuración inicial.",
             auto_delete_seconds=5
         )
         return
-    
+
     tenant_service = TenantService(session)
-    init_result = await tenant_service.initialize_tenant(message.from_user.id)
+    init_result = await tenant_service.initialize_tenant(uid)
     
     if not init_result["success"]:
         await menu_manager.send_temporary_message(

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -143,7 +143,7 @@ async def start_setup_callback(callback: CallbackQuery, session: AsyncSession):
     """Launch the guided setup from inline button."""
     from handlers.setup import start_setup
 
-    await start_setup(callback.message, session)
+    await start_setup(callback.message, session, user_id=callback.from_user.id)
     await callback.answer()
 
 
@@ -152,7 +152,7 @@ async def skip_to_admin_callback(callback: CallbackQuery, session: AsyncSession)
     """Directly open the admin menu, skipping setup."""
     from handlers.admin.admin_menu import admin_menu
 
-    await admin_menu(callback.message, session)
+    await admin_menu(callback.message, session, user_id=callback.from_user.id)
     await callback.answer()
 
 


### PR DESCRIPTION
## Summary
- ensure `start_setup` and `admin_menu` support explicit user id
- pass `user_id` from callback handlers when launching setup or admin menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852c88a9aac8329b9c61716b2428f17