### PR TITLE
Fix VIP revoke not kicking members

### DIFF
--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -385,7 +385,7 @@ async def vip_revoke(callback: CallbackQuery, session: AsyncSession):
         return await callback.answer()
     user_id = int(callback.data.split("_")[-1])
     sub_service = SubscriptionService(session)
-    await sub_service.revoke_subscription(user_id)
+    await sub_service.revoke_subscription(user_id, bot=callback.bot)
     await callback.answer("❌ Suscripción revocada", show_alert=True)
 
 


### PR DESCRIPTION
## Summary
- ensure `SubscriptionService.revoke_subscription` can remove users from the VIP channel
- pass the bot instance so revoking a subscription kicks the user

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560fddbd2883299aa3d19b9db55712