### PR TITLE
Fix VIP removal for aiogram v3

### DIFF
--- a/mybot/services/scheduler.py
+++ b/mybot/services/scheduler.py
@@ -94,7 +94,8 @@ async def run_vip_subscription_check(bot: Bot, session_factory: async_sessionmak
         for user in expired_users:
             try:
                 if vip_channel_id:
-                    await bot.kick_chat_member(vip_channel_id, user.id)
+                    await bot.ban_chat_member(vip_channel_id, user.id)
+                    await bot.unban_chat_member(vip_channel_id, user.id)
             except Exception as e:
                 logging.exception("Failed to remove %s from VIP channel: %s", user.id, e)
             user.role = "free"

--- a/mybot/services/subscription_service.py
+++ b/mybot/services/subscription_service.py
@@ -121,7 +121,8 @@ class SubscriptionService:
             vip_channel_id = await config_service.get_vip_channel_id()
             if vip_channel_id:
                 try:
-                    await bot.kick_chat_member(vip_channel_id, user_id)
+                    await bot.ban_chat_member(vip_channel_id, user_id)
+                    await bot.unban_chat_member(vip_channel_id, user_id)
                 except Exception as e:
                     logger.exception("Failed to remove %s from VIP channel: %s", user_id, e)
 


### PR DESCRIPTION
## Summary
- use `ban_chat_member`/`unban_chat_member` instead of removed `kick_chat_member`

## Testing
- `python -m py_compile mybot/services/subscription_service.py mybot/services/scheduler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856130a116483298092103f34bbd655