### PR TITLE
Update menu factory and role checks

### DIFF
--- a/mybot/keyboards/user_kb.py
+++ b/mybot/keyboards/user_kb.py
@@ -1,6 +1,7 @@
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.types import InlineKeyboardMarkup
 
+
 def get_free_user_menu_kb() -> InlineKeyboardMarkup:
     """Teclado para usuarios gratuitos."""
     builder = InlineKeyboardBuilder()
@@ -8,17 +9,16 @@ def get_free_user_menu_kb() -> InlineKeyboardMarkup:
     builder.button(text="💎 Ver Tarifas VIP", callback_data="show_vip_tariffs")
     builder.button(text="❓ Preguntas Frecuentes", callback_data="faq")
     builder.button(text="📞 Contactar Soporte", callback_data="contact_support")
-    builder.adjust(1) # Cada botón en su propia fila para mayor claridad
+    builder.adjust(1)  # Cada botón en su propia fila para mayor claridad
     return builder.as_markup()
+
 
 def get_main_menu_kb() -> InlineKeyboardMarkup:
     """Teclado principal para usuarios (ej. VIPs o con acceso general)."""
     builder = InlineKeyboardBuilder()
     builder.button(text="✅ Mi Suscripción", callback_data="my_subscription")
     builder.button(text="🎁 Mis Recompensas", callback_data="my_rewards")
-    builder.button(text="💬 Grupo VIP", url="https://t.me/your_vip_group_link") # Reemplaza con tu link
+    builder.button(text="💬 Grupo VIP", url="https://t.me/your_vip_group_link")  # Reemplaza con tu link
     builder.button(text="❓ Ayuda", callback_data="help_menu")
     builder.adjust(1)
     return builder.as_markup()
-
-# Puedes añadir más teclados de usuario aquí si los necesitas


### PR DESCRIPTION
## Summary
- refine user keyboards
- improve menu factory imports and menu creation logic
- add role-based fallback menu
- make `is_admin` async and integrate session checks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856643a6d1c83298166fc8a0f9e70bf