### PR TITLE
Add current_menu_state field

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -36,6 +36,8 @@ class User(AsyncAttrs, Base):
     username = Column(String, nullable=True)
     first_name = Column(String, nullable=True)
     last_name = Column(String, nullable=True)
+    # Menu state tracking for user navigation
+    current_menu_state = Column(String, default="main", nullable=False)
     points = Column(Float, default=0)
     level = Column(Integer, default=1)
     achievements = Column(JSON, default={})  # {'achievement_id': timestamp_isoformat}
@@ -58,6 +60,11 @@ class User(AsyncAttrs, Base):
 
     # Channel reactions tracking
     channel_reactions = Column(JSON, default={})  # {'message_id': True}
+
+    def __repr__(self):
+        return (
+            f"<User(id={self.id}, username='{self.username}', current_menu_state='{self.current_menu_state}')>"
+        )
 
 
 class Reward(AsyncAttrs, Base):


### PR DESCRIPTION
## Summary
- extend `User` model with `current_menu_state`
- add a `__repr__` showing the user's menu state

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68566bded4d48329bed2200172d8bba2