### PR TITLE
Update admin menu keyboard

### DIFF
--- a/mybot/keyboards/admin_kb.py
+++ b/mybot/keyboards/admin_kb.py
@@ -1,10 +1,59 @@
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
 
-
-def get_admin_kb():
-    """Return a minimal admin menu."""
-
+# Teclado principal de administración
+def get_admin_kb() -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
-    # Single button for the admin menu
-    builder.button(text="Botón de administración", callback_data="admin_button")
+    builder.button(text="👥 Gestionar Usuarios", callback_data="admin_users")
+    builder.button(text="📺 Gestionar Canales", callback_data="admin_channels")
+    builder.button(text="🎮 Configurar Gamificación", callback_data="setup_gamification")
+    builder.button(text="💳 Configurar Tarifas", callback_data="setup_tariffs")
+    builder.button(text="⚙️ Configuración del Bot", callback_data="admin_settings")
+    builder.button(text="🎲 Juego Kinky (Admin)", callback_data="admin_kinky_game")
+    builder.adjust(2)
+    return builder.as_markup()
+
+# Teclado para gestión de canales de administración (ejemplo, si lo necesitas)
+def get_admin_channels_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="➕ Añadir Canal VIP", callback_data="admin_add_vip_channel")
+    builder.button(text="➕ Añadir Canal Gratuito", callback_data="admin_add_free_channel")
+    builder.button(text="🔙 Volver al Panel Admin", callback_data="admin_main")
+    builder.adjust(1)
+    return builder.as_markup()
+
+# Teclado para gestión de gamificación de administración (ejemplo)
+def get_admin_gamification_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="🎯 Misiones", callback_data="admin_missions")
+    builder.button(text="🏅 Insignias", callback_data="admin_badges")
+    builder.button(text="🎁 Recompensas", callback_data="admin_rewards")
+    builder.button(text="📊 Niveles", callback_data="admin_levels")
+    builder.button(text="🔙 Volver a Config. Gamificación", callback_data="setup_gamification")
+    builder.adjust(2)
+    return builder.as_markup()
+
+# Teclado para gestión de tarifas de administración (ejemplo)
+def get_admin_tariffs_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="💎 Ver Tarifas Existentes", callback_data="admin_view_tariffs")
+    builder.button(text="➕ Crear Nueva Tarifa", callback_data="admin_create_tariff")
+    builder.button(text="🔙 Volver a Config. Tarifas", callback_data="setup_tariffs")
+    builder.adjust(1)
+    return builder.as_markup()
+
+# Teclado para gestión de usuarios de administración (ejemplo)
+def get_admin_users_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="🔍 Buscar Usuario", callback_data="admin_search_user")
+    builder.button(text="📝 Editar Rol de Usuario", callback_data="admin_edit_user_role")
+    builder.button(text="📊 Estadísticas de Usuarios", callback_data="admin_user_stats")
+    builder.button(text="🔙 Volver al Panel Admin", callback_data="admin_main")
+    builder.adjust(1)
+    return builder.as_markup()
+
+# Teclado para solicitar un ID de canal (ejemplo, si es necesario)
+def get_admin_channel_id_input_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="↩️ Cancelar", callback_data="cancel_channel_input")
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- extend admin keyboard with channel, gamification, tariff, and user management options
- keep main admin menu in menu_factory using get_admin_kb

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685756afd06083298c4a5e5c77e20142