### PR TITLE
Fix admin menu callbacks

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -16,7 +16,8 @@ from database.models import Tariff, Token
 from uuid import uuid4
 from sqlalchemy import select
 from utils.messages import BOT_MESSAGES
-from utils.keyboard_utils import get_admin_manage_content_keyboard # Importar la función del teclado
+from utils.keyboard_utils import get_admin_manage_content_keyboard  # Importar la función del teclado
+from keyboards.admin_channels_kb import get_manage_channels_menu_kb
 
 import logging
 
@@ -165,6 +166,23 @@ async def back_to_admin_main(callback: CallbackQuery, session: AsyncSession):
         logger.error(f"Error returning to admin main: {e}")
         await callback.answer("Error al cargar el menú principal", show_alert=True)
     
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_manage_channels")
+async def show_manage_channels(callback: CallbackQuery, session: AsyncSession):
+    """Show menu to select which channel to manage."""
+    if not is_admin(callback.from_user.id):
+        return await callback.answer("Acceso denegado", show_alert=True)
+
+    keyboard = get_manage_channels_menu_kb()
+    await menu_manager.update_menu(
+        callback,
+        "📺 **Gestionar Canales**\n\nElige una opción:",
+        keyboard,
+        session,
+        "admin_manage_channels",
+    )
     await callback.answer()
 
 # --- MODIFICACIÓN: RENOMBRADO Y REUTILIZADO PARA GESTIÓN DE GAMIFICACIÓN ---

--- a/mybot/keyboards/admin_channels_kb.py
+++ b/mybot/keyboards/admin_channels_kb.py
@@ -25,3 +25,13 @@ def get_wait_time_kb():
     builder.button(text="🔙 Volver", callback_data="admin_channels")
     builder.adjust(3)
     return builder.as_markup()
+
+
+def get_manage_channels_menu_kb():
+    """Keyboard to choose which channel to manage."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📢 Canal VIP", callback_data="admin_vip")
+    builder.button(text="💬 Canal Free", callback_data="admin_free")
+    builder.button(text="🔙 Volver", callback_data="admin_main_menu")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/keyboards/admin_kb.py
+++ b/mybot/keyboards/admin_kb.py
@@ -3,13 +3,12 @@ from aiogram.types import InlineKeyboardMarkup
 
 # Teclado principal de administración
 def get_admin_kb() -> InlineKeyboardMarkup:
+    """Main admin menu keyboard."""
     builder = InlineKeyboardBuilder()
-    builder.button(text="👥 Gestionar Usuarios", callback_data="admin_users")
-    builder.button(text="📺 Gestionar Canales", callback_data="admin_channels")
-    builder.button(text="🎮 Configurar Gamificación", callback_data="setup_gamification")
-    builder.button(text="💳 Configurar Tarifas", callback_data="setup_tariffs")
-    builder.button(text="⚙️ Configuración del Bot", callback_data="admin_settings")
-    builder.button(text="🎲 Juego Kinky (Admin)", callback_data="admin_kinky_game")
+    builder.button(text="👥 Gestionar Usuarios VIP", callback_data="vip_manage")
+    builder.button(text="📺 Gestionar Canales", callback_data="admin_manage_channels")
+    builder.button(text="🎮 Configurar Gamificación", callback_data="admin_kinky_game")
+    builder.button(text="⚙️ Configuración del Bot", callback_data="admin_bot_config")
     builder.adjust(2)
     return builder.as_markup()
 

--- a/mybot/keyboards/admin_main_kb.py
+++ b/mybot/keyboards/admin_main_kb.py
@@ -4,11 +4,9 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 def get_admin_main_kb():
     """Return the main admin inline keyboard."""
     builder = InlineKeyboardBuilder()
-    builder.button(text="📢 Canal VIP", callback_data="admin_vip")
-    builder.button(text="💬 Canal Free", callback_data="admin_free")
-    builder.button(text="🎮 Juego Kinky", callback_data="admin_kinky_game")
-    builder.button(text="🛠 Configuración del Bot", callback_data="admin_config")
-    builder.button(text="📈 Estadísticas", callback_data="admin_stats")
-    builder.button(text="🔙 Volver", callback_data="admin_back")
-    builder.adjust(1)
+    builder.button(text="👥 Gestionar Usuarios VIP", callback_data="vip_manage")
+    builder.button(text="📺 Gestionar Canales", callback_data="admin_manage_channels")
+    builder.button(text="🎮 Configurar Gamificación", callback_data="admin_kinky_game")
+    builder.button(text="⚙️ Configuración del Bot", callback_data="admin_bot_config")
+    builder.adjust(2)
     return builder.as_markup()

--- a/mybot/keyboards/admin_vip_kb.py
+++ b/mybot/keyboards/admin_vip_kb.py
@@ -6,6 +6,7 @@ def get_admin_vip_kb() -> InlineKeyboardBuilder:
     builder.button(text="📊 Estadísticas", callback_data="vip_stats")
     builder.button(text="🔑 Generar Token", callback_data="vip_generate_token")
     builder.button(text="👥 Suscriptores", callback_data="vip_manage")
+    builder.button(text="💳 Configurar Tarifas", callback_data="config_tarifas")
     builder.button(text="🏅 Asignar insignia", callback_data="vip_manual_badge")
     builder.button(text="📝 Publicar en Canal", callback_data="admin_send_channel_post")
     builder.button(text="⚙️ Configuración", callback_data="vip_config")


### PR DESCRIPTION
## Summary
- update admin keyboards with correct callback data
- add missing option for VIP tariff config
- add Manage Channels submenu with VIP and Free options
- wire up new admin handler for channel management

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68576c27c1d88329b4f5156df83b0050