### PR TITLE
Add free user menu

### DIFF
--- a/mybot/handlers/free_user.py
+++ b/mybot/handlers/free_user.py
@@ -1,162 +1,102 @@
-# mybot/handlers/free_user.py
 import logging
 from aiogram import Router, F
-from aiogram.types import Message, CallbackQuery
 from aiogram.filters import Command
-from sqlalchemy.ext.asyncio import AsyncSession # Importar AsyncSession
-from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import Message, CallbackQuery
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from keyboards.subscription_kb import (
-    get_subscription_kb,
-    get_free_info_kb,
-    get_free_game_kb,
-)
-from utils.user_roles import is_admin, is_vip # Asegúrate de que is_vip ahora espera 'bot' y 'session'
-from utils.menu_manager import menu_manager # Importar menu_manager
-from utils.menu_factory import menu_factory # Importar menu_factory
+from utils.user_roles import get_user_role
+from utils.menu_manager import menu_manager
+from keyboards.subscription_kb import get_subscription_kb
+from utils.messages import BOT_MESSAGES
+from utils.keyboard_utils import get_back_keyboard
 
-logger = logging.getLogger(__name__)
 router = Router()
+logger = logging.getLogger(__name__)
+
 
 @router.message(Command("subscribe"))
-async def subscription_menu(message: Message, session: AsyncSession): # Añadir session aquí
-    # Asume que is_admin y is_vip esperan session
-    if await is_admin(message.from_user.id, session) or await is_vip(message.bot, message.from_user.id, session):
+async def show_free_menu(message: Message, session: AsyncSession):
+    """Display the menu for free users."""
+    if await get_user_role(message.bot, message.from_user.id, session=session) != "free":
         return
 
-    # Usar menu_manager para mostrar el menú principal gratuito
-    text, keyboard = await menu_factory.create_menu("free_main", message.from_user.id, session, message.bot)
     await menu_manager.show_menu(
         message,
-        text,
-        keyboard,
+        BOT_MESSAGES.get("FREE_MENU_TEXT", "Menú gratuito"),
+        get_subscription_kb(),
         session,
-        "free_main", # Estado del menú para el historial
-        delete_origin_message=True # Opcional: elimina el mensaje del comando
+        "free_main",
+        delete_origin_message=True,
     )
 
-@router.callback_query(F.data == "free_info")
-async def show_info(callback: CallbackQuery, session: AsyncSession): # Añadir session aquí
-    """Display the info section for free users."""
-    text = "ℹ️ **Información General para Usuarios Gratuitos**\n\n" \
-           "Bienvenido a la sección de información. Aquí puedes encontrar " \
-           "detalles sobre cómo funciona el bot, sus características, " \
-           "y cómo obtener acceso VIP.\n\n" \
-           "*(¡Más información próximamente!)*"
-    
-    keyboard = get_free_info_kb()
-    
-    await menu_manager.update_menu(
-        callback,
-        text,
-        keyboard,
-        session,
-        "free_info_section" # Nuevo estado para el historial del menú
-    )
-    await callback.answer()
 
-# --- Nuevos manejadores para los botones dentro de "Información" ---
-@router.callback_query(F.data == "free_info_faq")
-async def show_faq(callback: CallbackQuery):
-    await callback.answer("Cargando Preguntas Frecuentes...", show_alert=False)
-    text = "❓ **Preguntas Frecuentes (FAQ)**\n\n" \
-           "**P: ¿Cómo funciona este bot?**\n" \
-           "R: Es un bot de interacción y comunidad con contenido exclusivo.\n\n" \
-           "**P: ¿Cómo consigo acceso VIP?**\n" \
-           "R: Puedes obtener acceso VIP en la sección 'Obtener VIP' del menú principal.\n\n" \
-           "**P: ¿El mini juego es gratuito?**\n" \
-           "R: Sí, el mini juego es para usuarios gratuitos. ¡Diviértete!"
-    
-    # Podrías crear un nuevo teclado para esta sección o reusar get_free_info_kb() con un botón de volver
-    builder = InlineKeyboardBuilder()
-    builder.button(text="🔙 Volver a Información", callback_data="free_info") # Volver a la sección de info
-    await callback.message.edit_text(text, reply_markup=builder.as_markup())
-
-
-@router.callback_query(F.data == "free_info_news")
-async def show_news(callback: CallbackQuery):
-    await callback.answer("Cargando Novedades...", show_alert=False)
-    text = "📢 **Novedades y Anuncios**\n\n" \
-           "• **22 de Junio, 2025**: Lanzamiento del nuevo sistema de gamificación (solo VIP).\n" \
-           "• **15 de Junio, 2025**: Actualización de contenido en el canal VIP.\n" \
-           "• **01 de Junio, 2025**: ¡Hemos alcanzado 1000 usuarios! Gracias por tu apoyo."
-    
-    builder = InlineKeyboardBuilder()
-    builder.button(text="🔙 Volver a Información", callback_data="free_info")
-    await callback.message.edit_text(text, reply_markup=builder.as_markup())
-
-
-# --- Manejador para el botón "Mini Juego Kinky" ---
-@router.callback_query(F.data == "free_game")
-async def free_game_menu(callback: CallbackQuery, session: AsyncSession): # Añadir session aquí
-    """Display the mini game section for free users."""
-    text = "🧩 **Mini Juego Kinky (versión gratuita)**\n\n" \
-           "Este es un divertido mini juego para pasar el rato. " \
-           "¡Prueba tu suerte y ve qué tan bien te va!\n\n" \
-           "*(¡El juego estará disponible pronto!)*"
-    
-    keyboard = get_free_game_kb()
-    
-    await menu_manager.update_menu(
-        callback,
-        text,
-        keyboard,
-        session,
-        "free_game_section" # Nuevo estado para el historial del menú
-    )
-    await callback.answer()
-
-# --- Nuevos manejadores para los botones dentro de "Mini Juego Kinky" ---
-@router.callback_query(F.data == "free_game_start")
-async def start_free_game(callback: CallbackQuery):
-    await callback.answer("Iniciando el juego... (Funcionalidad en desarrollo)", show_alert=True)
-    # Aquí iría la lógica para iniciar el juego
-    # Por ahora, puedes dejar un mensaje simple o redirigir a un menú de juego real
-
-@router.callback_query(F.data == "free_game_scores")
-async def show_free_game_scores(callback: CallbackQuery):
-    await callback.answer("Cargando puntuaciones...", show_alert=False)
-    text = "🏆 **Mejores Puntuaciones del Mini Juego Kinky**\n\n" \
-           "Aquí verás los jugadores con las mejores puntuaciones.\n\n" \
-           "1. Anónimo_123: 500 puntos\n" \
-           "2. KinkyLover: 450 puntos\n" \
-           "3. JugadorX: 400 puntos\n\n" \
-           "*(¡Juega para aparecer en el ranking!)*"
-    
-    builder = InlineKeyboardBuilder()
-    builder.button(text="🔙 Volver al Juego", callback_data="free_game") # Volver al menú del juego
-    await callback.message.edit_text(text, reply_markup=builder.as_markup())
-
-
-# --- Manejador para el botón "Obtener VIP" ---
-@router.callback_query(F.data == "free_get_vip")
-async def handle_get_vip(callback: CallbackQuery):
-    await callback.answer("Redirigiendo a la información VIP...", show_alert=False)
-    text = "👑 **Conviértete en Miembro VIP**\n\n" \
-           "Obtén acceso exclusivo a:\n" \
-           "• Contenido premium y eventos\n" \
-           "• Misiones y recompensas avanzadas\n" \
-           "• Soporte prioritario\n\n" \
-           "¡No te lo pierdas!\n\n" \
-           "*(Aquí iría la información sobre cómo comprar la suscripción VIP, por ejemplo, enlaces a tu pasarela de pago o instrucciones.)*"
-    
-    builder = InlineKeyboardBuilder()
-    builder.button(text="🔗 Comprar Suscripción", url="https://t.me/TuEnlaceDePagoVIP") # Reemplaza con tu enlace de pago
-    builder.button(text="🔙 Volver al Menú Principal", callback_data="free_main_menu")
-    await callback.message.edit_text(text, reply_markup=builder.as_markup())
-
-
-# --- Manejador para volver al menú principal gratuito (MUY IMPORTANTE) ---
 @router.callback_query(F.data == "free_main_menu")
-async def navigate_to_free_main_menu(callback: CallbackQuery, session: AsyncSession):
-    """Navigates back to the main free user menu."""
-    text, keyboard = await menu_factory.create_menu("free_main", callback.from_user.id, session, callback.bot)
+async def cb_free_main_menu(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
-        text,
-        keyboard,
+        BOT_MESSAGES.get("FREE_MENU_TEXT", "Menú gratuito"),
+        get_subscription_kb(),
         session,
-        "free_main"
+        "free_main",
     )
     await callback.answer()
 
+
+@router.callback_query(F.data == "free_benefits")
+async def cb_free_benefits(callback: CallbackQuery, session: AsyncSession):
+    await menu_manager.update_menu(
+        callback,
+        BOT_MESSAGES.get("FREE_BENEFITS_TEXT", "Beneficios"),
+        get_back_keyboard("free_main_menu"),
+        session,
+        "free_benefits",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "free_limits")
+async def cb_free_limits(callback: CallbackQuery, session: AsyncSession):
+    await menu_manager.update_menu(
+        callback,
+        BOT_MESSAGES.get("FREE_LIMITS_TEXT", "Límites"),
+        get_back_keyboard("free_main_menu"),
+        session,
+        "free_limits",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "free_content")
+async def cb_free_content(callback: CallbackQuery, session: AsyncSession):
+    await menu_manager.update_menu(
+        callback,
+        BOT_MESSAGES.get("FREE_CONTENT_TEXT", "Contenido"),
+        get_back_keyboard("free_main_menu"),
+        session,
+        "free_content",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "free_upgrade")
+async def cb_free_upgrade(callback: CallbackQuery, session: AsyncSession):
+    await menu_manager.update_menu(
+        callback,
+        BOT_MESSAGES.get("FREE_UPGRADE_TEXT", "Sube a VIP"),
+        get_back_keyboard("free_main_menu"),
+        session,
+        "free_upgrade",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "free_game")
+async def cb_free_game(callback: CallbackQuery, session: AsyncSession):
+    await menu_manager.update_menu(
+        callback,
+        BOT_MESSAGES.get("FREE_GAME_TEXT", "Mini juego"),
+        get_back_keyboard("free_main_menu"),
+        session,
+        "free_game",
+    )
+    await callback.answer()

--- a/mybot/keyboards/subscription_kb.py
+++ b/mybot/keyboards/subscription_kb.py
@@ -5,9 +5,11 @@ from aiogram.types import InlineKeyboardMarkup
 def get_subscription_kb() -> InlineKeyboardMarkup:
     """Return the menu keyboard for free users (main menu)."""
     builder = InlineKeyboardBuilder()
-    builder.button(text="ℹ️ Información", callback_data="free_info")
-    builder.button(text="🧩 Mini Juego Kinky", callback_data="free_game")
-    builder.button(text="🔗 Canal Gratuito", url="https://t.me/TuCanalGratuito") # Considera añadir un enlace real aquí
+    builder.button(text="👀 Ver beneficios", callback_data="free_benefits")
+    builder.button(text="🚫 Ver límites del plan", callback_data="free_limits")
+    builder.button(text="🔓 Contenido gratuito", callback_data="free_content")
+    builder.button(text="🚀 Subir a VIP", callback_data="free_upgrade")
+    builder.button(text="🎮 Mini Juego Kinky", callback_data="free_game")
     builder.adjust(1)
     return builder.as_markup()
 

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -105,6 +105,12 @@ BOT_MESSAGES = {
     "level_created": "✅ Nivel creado correctamente.",
     "level_updated": "✅ Nivel actualizado.",
     "level_deleted": "❌ Nivel eliminado.",
+    "FREE_MENU_TEXT": "🌟 *Bienvenido*\nEscoge una opción para conocer las ventajas del bot.",
+    "FREE_BENEFITS_TEXT": "👀 *Beneficios VIP*\nAccede a contenido exclusivo y experiencias completas.",
+    "FREE_LIMITS_TEXT": "🚫 *Límites del plan gratuito*\nAlgunas funciones están restringidas para usuarios VIP.",
+    "FREE_CONTENT_TEXT": "🔓 *Contenido gratuito disponible*\nÚnete a nuestro canal abierto y participa en eventos ocasionales.",
+    "FREE_UPGRADE_TEXT": "🚀 *Sube a VIP*\nAdquiere la suscripción para desbloquear todo el contenido.",
+    "FREE_GAME_TEXT": "🎮 *Mini Juego Kinky*\nPróximamente podrás jugar desde aquí.",
 }
 
 # Textos descriptivos para las insignias disponibles en el sistema.


### PR DESCRIPTION
## Summary
- implement simple menu for free users
- add callbacks and texts for free menu actions
- update free user keyboard with new options

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584b910530832997ebb13aa0f6c838