### PR TITLE
Implement seductive free menu

### DIFF
--- a/mybot/handlers/free_user.py
+++ b/mybot/handlers/free_user.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from utils.user_roles import get_user_role
 from utils.menu_manager import menu_manager
-from keyboards.subscription_kb import get_subscription_kb
+from keyboards.subscription_kb import get_free_main_menu_kb
 from utils.messages import BOT_MESSAGES
 from utils.keyboard_utils import get_back_keyboard
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.message(Command("subscribe"))
-async def show_free_menu(message: Message, session: AsyncSession):
+async def show_free_main_menu(message: Message, session: AsyncSession):
     """Display the menu for free users."""
     if await get_user_role(message.bot, message.from_user.id, session=session) != "free":
         return
@@ -23,7 +23,7 @@ async def show_free_menu(message: Message, session: AsyncSession):
     await menu_manager.show_menu(
         message,
         BOT_MESSAGES.get("FREE_MENU_TEXT", "Menú gratuito"),
-        get_subscription_kb(),
+        get_free_main_menu_kb(),
         session,
         "free_main",
         delete_origin_message=True,
@@ -35,57 +35,69 @@ async def cb_free_main_menu(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
         BOT_MESSAGES.get("FREE_MENU_TEXT", "Menú gratuito"),
-        get_subscription_kb(),
+        get_free_main_menu_kb(),
         session,
         "free_main",
     )
     await callback.answer()
 
 
-@router.callback_query(F.data == "free_benefits")
-async def cb_free_benefits(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "free_about")
+async def cb_free_about(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
-        BOT_MESSAGES.get("FREE_BENEFITS_TEXT", "Beneficios"),
+        BOT_MESSAGES.get("FREE_ABOUT_TEXT", "Sobre mí"),
         get_back_keyboard("free_main_menu"),
         session,
-        "free_benefits",
+        "free_about",
     )
     await callback.answer()
 
 
-@router.callback_query(F.data == "free_limits")
-async def cb_free_limits(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "free_find")
+async def cb_free_find(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
-        BOT_MESSAGES.get("FREE_LIMITS_TEXT", "Límites"),
+        BOT_MESSAGES.get("FREE_FIND_TEXT", "Información"),
         get_back_keyboard("free_main_menu"),
         session,
-        "free_limits",
+        "free_find",
     )
     await callback.answer()
 
 
-@router.callback_query(F.data == "free_content")
-async def cb_free_content(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "free_free")
+async def cb_free_free(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
-        BOT_MESSAGES.get("FREE_CONTENT_TEXT", "Contenido"),
+        BOT_MESSAGES.get("FREE_FREE_TEXT", "Contenido gratuito"),
         get_back_keyboard("free_main_menu"),
         session,
-        "free_content",
+        "free_free",
     )
     await callback.answer()
 
 
-@router.callback_query(F.data == "free_upgrade")
-async def cb_free_upgrade(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "free_vip")
+async def cb_free_vip(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
-        BOT_MESSAGES.get("FREE_UPGRADE_TEXT", "Sube a VIP"),
+        BOT_MESSAGES.get("FREE_VIP_TEXT", "Contenido VIP"),
         get_back_keyboard("free_main_menu"),
         session,
-        "free_upgrade",
+        "free_vip",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "free_private")
+async def cb_free_private(callback: CallbackQuery, session: AsyncSession):
+    await menu_manager.update_menu(
+        callback,
+        BOT_MESSAGES.get("FREE_PRIVATE_TEXT", "Sesiones privadas"),
+        get_back_keyboard("free_main_menu"),
+        session,
+        "free_private",
     )
     await callback.answer()
 

--- a/mybot/keyboards/subscription_kb.py
+++ b/mybot/keyboards/subscription_kb.py
@@ -2,16 +2,21 @@
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.types import InlineKeyboardMarkup
 
-def get_subscription_kb() -> InlineKeyboardMarkup:
-    """Return the menu keyboard for free users (main menu)."""
+def get_free_main_menu_kb() -> InlineKeyboardMarkup:
+    """Return the main menu keyboard for free users."""
     builder = InlineKeyboardBuilder()
-    builder.button(text="👀 Ver beneficios", callback_data="free_benefits")
-    builder.button(text="🚫 Ver límites del plan", callback_data="free_limits")
-    builder.button(text="🔓 Contenido gratuito", callback_data="free_content")
-    builder.button(text="🚀 Subir a VIP", callback_data="free_upgrade")
-    builder.button(text="🎮 Mini Juego Kinky", callback_data="free_game")
+    builder.button(text="📌 Sobre mí", callback_data="free_about")
+    builder.button(text="🪞 Qué puedes encontrar aquí", callback_data="free_find")
+    builder.button(text="🎁 Lo que sí puedes ver gratis", callback_data="free_free")
+    builder.button(text="🔒 Lo que te estás perdiendo (contenido VIP)", callback_data="free_vip")
+    builder.button(text="🔥 Sesiones privadas y contenido personalizado", callback_data="free_private")
+    builder.button(text="🎮 Probar el Juego Kinky (versión gratuita)", callback_data="free_game")
     builder.adjust(1)
     return builder.as_markup()
+
+def get_subscription_kb() -> InlineKeyboardMarkup:
+    """Alias for backward compatibility."""
+    return get_free_main_menu_kb()
 
 def get_free_info_kb() -> InlineKeyboardMarkup:
     """Keyboard shown in the information section."""

--- a/mybot/utils/menu_factory.py
+++ b/mybot/utils/menu_factory.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from utils.user_roles import get_user_role
 from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.vip_main_kb import get_vip_main_kb
-from keyboards.subscription_kb import get_subscription_kb
+from keyboards.subscription_kb import get_free_main_menu_kb
 from keyboards.setup_kb import (
     get_setup_main_kb, 
     get_setup_channels_kb, 
@@ -92,7 +92,7 @@ class MenuFactory:
                 "🌟 **Bienvenido a los Kinkys**\n\n"
                 "Explora nuestro contenido gratuito y descubre todo lo que tenemos para ti. "
                 "¿Listo para una experiencia única?",
-                get_subscription_kb()
+                get_free_main_menu_kb()
             )
     
     async def _create_setup_menu(
@@ -265,7 +265,7 @@ class MenuFactory:
         elif role == "vip":
             return (text, get_vip_main_kb())
         else: # Default for 'free' or unknown
-            return (text, get_subscription_kb())
+            return (text, get_free_main_menu_kb())
 
     def create_setup_choice_menu(self) -> Tuple[str, InlineKeyboardMarkup]:
         """

--- a/mybot/utils/menu_utils.py
+++ b/mybot/utils/menu_utils.py
@@ -6,7 +6,7 @@ from database.models import set_user_menu_state
 from utils.user_roles import get_user_role
 from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.vip_main_kb import get_vip_main_kb
-from keyboards.subscription_kb import get_subscription_kb
+from keyboards.subscription_kb import get_free_main_menu_kb
 
 
 def _menu_details(role: str):
@@ -15,7 +15,7 @@ def _menu_details(role: str):
         return "Panel de Administración", get_admin_main_kb(), "admin_main"
     if role == "vip":
         return "Bienvenido al Diván de Diana", get_vip_main_kb(), "vip_main"
-    return "Bienvenido a los Kinkys", get_subscription_kb(), "free_main"
+    return "Bienvenido a los Kinkys", get_free_main_menu_kb(), "free_main"
 
 # Cache to store the latest menu message for each user
 MENU_CACHE: dict[int, tuple[int, int]] = {}

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -105,12 +105,34 @@ BOT_MESSAGES = {
     "level_created": "✅ Nivel creado correctamente.",
     "level_updated": "✅ Nivel actualizado.",
     "level_deleted": "❌ Nivel eliminado.",
-    "FREE_MENU_TEXT": "🌟 *Bienvenido*\nEscoge una opción para conocer las ventajas del bot.",
-    "FREE_BENEFITS_TEXT": "👀 *Beneficios VIP*\nAccede a contenido exclusivo y experiencias completas.",
-    "FREE_LIMITS_TEXT": "🚫 *Límites del plan gratuito*\nAlgunas funciones están restringidas para usuarios VIP.",
-    "FREE_CONTENT_TEXT": "🔓 *Contenido gratuito disponible*\nÚnete a nuestro canal abierto y participa en eventos ocasionales.",
-    "FREE_UPGRADE_TEXT": "🚀 *Sube a VIP*\nAdquiere la suscripción para desbloquear todo el contenido.",
-    "FREE_GAME_TEXT": "🎮 *Mini Juego Kinky*\nPróximamente podrás jugar desde aquí.",
+    "FREE_MENU_TEXT": "✨ *Bienvenid@ a mi espacio gratuito*\n\nElige y descubre un poco de mi mundo...",
+    "FREE_ABOUT_TEXT": (
+        "📌 *Sobre mí*\n"
+        "Soy Diana, aunque cuando la noche se enciende me conocen como *Señorita Kinky*. "
+        "Te invito a un recorrido sensual y divertido. Esto es solo la entrada..."
+    ),
+    "FREE_FIND_TEXT": (
+        "🪞 *Qué puedes encontrar aquí*\n"
+        "Retos, consejos y un vistazo a mi universo más travieso. Todo pensado para que quieras más."
+    ),
+    "FREE_FREE_TEXT": (
+        "🎁 *Lo que sí puedes ver gratis*\n"
+        "Acceso a mi canal abierto y algunos eventos especiales. Una probadita que enciende la curiosidad."
+    ),
+    "FREE_VIP_TEXT": (
+        "🔒 *Lo que te estás perdiendo (contenido VIP)*\n"
+        "Fotos y videos exclusivos, juegos completos y mi atención más personal. "
+        "Ser VIP es vivir la experiencia completa."
+    ),
+    "FREE_PRIVATE_TEXT": (
+        "🔥 *Sesiones privadas y contenido personalizado*\n"
+        "Reserva un encuentro íntimo conmigo o solicita tu video a medida. "
+        "Tus fantasías pueden hacerse realidad."
+    ),
+    "FREE_GAME_TEXT": (
+        "🎮 *Juego Kinky (versión gratuita)*\n"
+        "Disfruta de un adelanto de la diversión. La versión completa te espera en el VIP."
+    ),
 }
 
 # Textos descriptivos para las insignias disponibles en el sistema.


### PR DESCRIPTION
## Summary
- add emotional texts for free user screens
- update free user handler with new menu items
- rework free user keyboards with new options
- hook new keyboard in menu utilities and factory

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858556760f883299676452aa2cdcecb