### PR TITLE
Update free user keyboard

### DIFF
--- a/mybot/handlers/free_user.py
+++ b/mybot/handlers/free_user.py
@@ -42,62 +42,50 @@ async def cb_free_main_menu(callback: CallbackQuery, session: AsyncSession):
     await callback.answer()
 
 
-@router.callback_query(F.data == "free_about")
-async def cb_free_about(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "free_gift")
+async def cb_free_gift(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
-        BOT_MESSAGES.get("FREE_ABOUT_TEXT", "Sobre mí"),
+        BOT_MESSAGES.get("FREE_GIFT_TEXT", "Desbloquear regalo"),
         get_back_keyboard("free_main_menu"),
         session,
-        "free_about",
+        "free_gift",
     )
     await callback.answer()
 
 
-@router.callback_query(F.data == "free_find")
-async def cb_free_find(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "free_packs")
+async def cb_free_packs(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
-        BOT_MESSAGES.get("FREE_FIND_TEXT", "Información"),
+        BOT_MESSAGES.get("FREE_PACKS_TEXT", "Packs exclusivos"),
         get_back_keyboard("free_main_menu"),
         session,
-        "free_find",
+        "free_packs",
     )
     await callback.answer()
 
 
-@router.callback_query(F.data == "free_free")
-async def cb_free_free(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "free_vip_explore")
+async def cb_free_vip_explore(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
-        BOT_MESSAGES.get("FREE_FREE_TEXT", "Contenido gratuito"),
+        BOT_MESSAGES.get("FREE_VIP_EXPLORE_TEXT", "Canal VIP"),
         get_back_keyboard("free_main_menu"),
         session,
-        "free_free",
+        "free_vip_explore",
     )
     await callback.answer()
 
 
-@router.callback_query(F.data == "free_vip")
-async def cb_free_vip(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "free_custom")
+async def cb_free_custom(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
-        BOT_MESSAGES.get("FREE_VIP_TEXT", "Contenido VIP"),
+        BOT_MESSAGES.get("FREE_CUSTOM_TEXT", "Contenido personalizado"),
         get_back_keyboard("free_main_menu"),
         session,
-        "free_vip",
-    )
-    await callback.answer()
-
-
-@router.callback_query(F.data == "free_private")
-async def cb_free_private(callback: CallbackQuery, session: AsyncSession):
-    await menu_manager.update_menu(
-        callback,
-        BOT_MESSAGES.get("FREE_PRIVATE_TEXT", "Sesiones privadas"),
-        get_back_keyboard("free_main_menu"),
-        session,
-        "free_private",
+        "free_custom",
     )
     await callback.answer()
 
@@ -110,5 +98,17 @@ async def cb_free_game(callback: CallbackQuery, session: AsyncSession):
         get_back_keyboard("free_main_menu"),
         session,
         "free_game",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "free_follow")
+async def cb_free_follow(callback: CallbackQuery, session: AsyncSession):
+    await menu_manager.update_menu(
+        callback,
+        BOT_MESSAGES.get("FREE_FOLLOW_TEXT", "Dónde seguirme"),
+        get_back_keyboard("free_main_menu"),
+        session,
+        "free_follow",
     )
     await callback.answer()

--- a/mybot/keyboards/subscription_kb.py
+++ b/mybot/keyboards/subscription_kb.py
@@ -5,12 +5,12 @@ from aiogram.types import InlineKeyboardMarkup
 def get_free_main_menu_kb() -> InlineKeyboardMarkup:
     """Return the main menu keyboard for free users."""
     builder = InlineKeyboardBuilder()
-    builder.button(text="📌 Sobre mí", callback_data="free_about")
-    builder.button(text="🪞 Qué puedes encontrar aquí", callback_data="free_find")
-    builder.button(text="🎁 Lo que sí puedes ver gratis", callback_data="free_free")
-    builder.button(text="🔒 Lo que te estás perdiendo (contenido VIP)", callback_data="free_vip")
-    builder.button(text="🔥 Sesiones privadas y contenido personalizado", callback_data="free_private")
-    builder.button(text="🎮 Probar el Juego Kinky (versión gratuita)", callback_data="free_game")
+    builder.button(text="🎁 Desbloquear regalo", callback_data="free_gift")
+    builder.button(text="🎀 Ver mis packs exclusivos", callback_data="free_packs")
+    builder.button(text="🔐 Explorar el canal VIP", callback_data="free_vip_explore")
+    builder.button(text="💌 Quiero contenido personalizado", callback_data="free_custom")
+    builder.button(text="🎮 Modo gratuito del juego Kinky", callback_data="free_game")
+    builder.button(text="🌐 ¿Dónde más seguirme?", callback_data="free_follow")
     builder.adjust(1)
     return builder.as_markup()
 

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -106,32 +106,29 @@ BOT_MESSAGES = {
     "level_updated": "✅ Nivel actualizado.",
     "level_deleted": "❌ Nivel eliminado.",
     "FREE_MENU_TEXT": "✨ *Bienvenid@ a mi espacio gratuito*\n\nElige y descubre un poco de mi mundo...",
-    "FREE_ABOUT_TEXT": (
-        "📌 *Sobre mí*\n"
-        "Soy Diana, aunque cuando la noche se enciende me conocen como *Señorita Kinky*. "
-        "Te invito a un recorrido sensual y divertido. Esto es solo la entrada..."
+    "FREE_GIFT_TEXT": (
+        "🎁 *Desbloquear regalo*\n"
+        "Activa tu obsequio de bienvenida y descubre los primeros detalles de todo lo que tengo para ti."
     ),
-    "FREE_FIND_TEXT": (
-        "🪞 *Qué puedes encontrar aquí*\n"
-        "Retos, consejos y un vistazo a mi universo más travieso. Todo pensado para que quieras más."
+    "FREE_PACKS_TEXT": (
+        "🎀 *Ver mis packs exclusivos*\n"
+        "Explora mis colecciones de fotos y videos más picantes listas para ti."
     ),
-    "FREE_FREE_TEXT": (
-        "🎁 *Lo que sí puedes ver gratis*\n"
-        "Acceso a mi canal abierto y algunos eventos especiales. Una probadita que enciende la curiosidad."
+    "FREE_VIP_EXPLORE_TEXT": (
+        "🔐 *Explorar el canal VIP*\n"
+        "Aquí comparto el contenido más atrevido y sorpresas solo para miembros. ¿Te unes?"
     ),
-    "FREE_VIP_TEXT": (
-        "🔒 *Lo que te estás perdiendo (contenido VIP)*\n"
-        "Fotos y videos exclusivos, juegos completos y mi atención más personal. "
-        "Ser VIP es vivir la experiencia completa."
-    ),
-    "FREE_PRIVATE_TEXT": (
-        "🔥 *Sesiones privadas y contenido personalizado*\n"
-        "Reserva un encuentro íntimo conmigo o solicita tu video a medida. "
-        "Tus fantasías pueden hacerse realidad."
+    "FREE_CUSTOM_TEXT": (
+        "💌 *Quiero contenido personalizado*\n"
+        "Cuéntame tus fantasías y recibirás algo hecho solo para ti."
     ),
     "FREE_GAME_TEXT": (
-        "🎮 *Juego Kinky (versión gratuita)*\n"
+        "🎮 *Modo gratuito del juego Kinky*\n"
         "Disfruta de un adelanto de la diversión. La versión completa te espera en el VIP."
+    ),
+    "FREE_FOLLOW_TEXT": (
+        "🌐 *¿Dónde más seguirme?*\n"
+        "Encuentra todos mis enlaces y redes para que no te pierdas nada."
     ),
 }
 


### PR DESCRIPTION
## Summary
- update free user inline keyboard options
- add new descriptions for each free menu item
- handle new callbacks for the free menu buttons

## Testing
- `python -m py_compile mybot/handlers/free_user.py mybot/keyboards/subscription_kb.py mybot/utils/messages.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685860fe10b883299ab224a70a0c899e