### PR TITLE
Add special packs menu

### DIFF
--- a/mybot/keyboards/packs_kb.py
+++ b/mybot/keyboards/packs_kb.py
@@ -1,0 +1,21 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+
+
+def get_packs_list_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="💫 Encanto Inicial – $150 MXN", callback_data="pack_1")
+    builder.button(text="🔥 Sensualidad Revelada – $200 MXN", callback_data="pack_2")
+    builder.button(text="💋 Pasión Desbordante – $250 MXN", callback_data="pack_3")
+    builder.button(text="🔞 Intimidad Explosiva – $300 MXN", callback_data="pack_4")
+    builder.button(text="🔙 Volver", callback_data="free_main_menu")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_pack_detail_kb(pack_id: int) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Me interesa 🔥", callback_data=f"pack_interest_{pack_id}")
+    builder.button(text="🔙 Regresar", callback_data="free_packs")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -110,10 +110,18 @@ BOT_MESSAGES = {
         "🎁 *Desbloquear regalo*\n"
         "Activa tu obsequio de bienvenida y descubre los primeros detalles de todo lo que tengo para ti."
     ),
-    "FREE_PACKS_TEXT": (
-        "🎀 *Ver mis packs exclusivos*\n"
-        "Explora mis colecciones de fotos y videos más picantes listas para ti."
+    "PACKS_MENU_TEXT": (
+        "🎀 *Paquetes especiales de Diana* 🎀\n\n"
+        "¿Quieres una probadita de mis momentos más intensos?\n\n"
+        "Estos son sets que puedes comprar directamente, sin suscripción. "
+        "Cada uno incluye fotos y videos explícitos. 🥵\n\n"
+        "🛍️ Elige tu favorito y presiona *“Me interesa”*. Yo me pondré en contacto contigo."
     ),
+    "PACK_1_DETAILS": "💫 *Encanto Inicial – $150 MXN*\n\nFotos y videos perfectos para iniciar tu colección.",
+    "PACK_2_DETAILS": "🔥 *Sensualidad Revelada – $200 MXN*\n\nUn nivel más de pasión en cada imagen.",
+    "PACK_3_DETAILS": "💋 *Pasión Desbordante – $250 MXN*\n\nMis momentos más atrevidos capturados para ti.",
+    "PACK_4_DETAILS": "🔞 *Intimidad Explosiva – $300 MXN*\n\nContenido explícito y sin censura.",
+    "PACK_INTEREST_REPLY": "💌 ¡Gracias! Recibí tu interés. Me pondré en contacto contigo muy pronto. O si no quieres esperar escríbeme directo a mi chat privado en ,,@DianaKinky ",
     "FREE_VIP_EXPLORE_TEXT": (
         "🔐 *Explorar el canal VIP*\n"
         "Aquí comparto el contenido más atrevido y sorpresas solo para miembros. ¿Te unes?"

--- a/mybot/utils/notify_admins.py
+++ b/mybot/utils/notify_admins.py
@@ -1,0 +1,11 @@
+import logging
+from aiogram import Bot
+from utils.config import ADMIN_IDS
+
+
+async def notify_admins(bot: Bot, text: str) -> None:
+    for admin_id in ADMIN_IDS:
+        try:
+            await bot.send_message(admin_id, text)
+        except Exception as e:
+            logging.error(f"Failed to notify admin {admin_id}: {e}")


### PR DESCRIPTION
## Summary
- add keyboard and handlers for special pack menu
- notify admins when users show interest
- store pack texts in messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858641beda08329ba35a2ddf2bd5ca1