### PR TITLE
Add VIP explore promo

### DIFF
--- a/mybot/handlers/free_user.py
+++ b/mybot/handlers/free_user.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from utils.user_roles import get_user_role
 from utils.menu_manager import menu_manager
-from keyboards.subscription_kb import get_free_main_menu_kb
+from keyboards.subscription_kb import get_free_main_menu_kb, get_vip_explore_kb
 from keyboards.packs_kb import get_packs_list_kb, get_pack_detail_kb
 from utils.messages import BOT_MESSAGES
 from utils.keyboard_utils import get_back_keyboard
@@ -82,7 +82,7 @@ async def cb_free_vip_explore(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
         BOT_MESSAGES.get("FREE_VIP_EXPLORE_TEXT", "Canal VIP"),
-        get_back_keyboard("free_main_menu"),
+        get_vip_explore_kb(),
         session,
         "free_vip_explore",
     )
@@ -121,6 +121,22 @@ async def cb_free_follow(callback: CallbackQuery, session: AsyncSession):
         get_back_keyboard("free_main_menu"),
         session,
         "free_follow",
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "vip_explore_interest")
+async def cb_vip_explore_interest(callback: CallbackQuery, session: AsyncSession):
+    """Notify admins about VIP interest and thank the user."""
+    user = callback.from_user
+    notify_text = (
+        f"Interés en VIP de {user.first_name} (@{user.username or user.id})"
+    )
+    await notify_admins(callback.bot, notify_text)
+    await menu_manager.send_temporary_message(
+        callback.message,
+        BOT_MESSAGES.get("VIP_INTEREST_REPLY"),
+        auto_delete_seconds=8,
     )
     await callback.answer()
 

--- a/mybot/keyboards/subscription_kb.py
+++ b/mybot/keyboards/subscription_kb.py
@@ -14,6 +14,14 @@ def get_free_main_menu_kb() -> InlineKeyboardMarkup:
     builder.adjust(1)
     return builder.as_markup()
 
+def get_vip_explore_kb() -> InlineKeyboardMarkup:
+    """Keyboard shown in the free VIP explore section."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Me interesa 🔥", callback_data="vip_explore_interest")
+    builder.button(text="🔙 Regresar", callback_data="free_main_menu")
+    builder.adjust(1)
+    return builder.as_markup()
+
 def get_subscription_kb() -> InlineKeyboardMarkup:
     """Alias for backward compatibility."""
     return get_free_main_menu_kb()

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -123,8 +123,17 @@ BOT_MESSAGES = {
     "PACK_4_DETAILS": "🔞 *Intimidad Explosiva – $300 MXN*\n\nContenido explícito y sin censura.",
     "PACK_INTEREST_REPLY": "💌 ¡Gracias! Recibí tu interés. Me pondré en contacto contigo muy pronto. O si no quieres esperar escríbeme directo a mi chat privado en ,,@DianaKinky ",
     "FREE_VIP_EXPLORE_TEXT": (
-        "🔐 *Explorar el canal VIP*\n"
-        "Aquí comparto el contenido más atrevido y sorpresas solo para miembros. ¿Te unes?"
+        "🔐 *Bienvenido al Diván de Diana* 🔐\n\n"
+        "¿Te atreves a entrar a mi universo sin censura?\n\n"
+        "✨ Más de 2000 archivos privados\n"
+        "🎬 Videos explícitos sin censura\n"
+        "🎁 Descuentos en contenido personalizado\n"
+        "👀 Acceso exclusivo a mis historias diarias\n\n"
+        "📌 Precio: *$350 MXN / mes*"
+    ),
+    "VIP_INTEREST_REPLY": (
+        "💌 ¡Gracias! Recibí tu interés. Me pondré en contacto contigo muy pronto. "
+        "O si no quieres esperar escríbeme directo a mi chat privado en ,,@DianaKinky "
     ),
     "FREE_CUSTOM_TEXT": (
         "💌 *Quiero contenido personalizado*\n"


### PR DESCRIPTION
## Summary
- expand FREE_VIP_EXPLORE_TEXT with subscription promo
- add keyboard to express interest in VIP channel
- handle interest callback to notify admins

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68586b6b4f248329b7b1bed87ff0ac94