### PR TITLE
Update VIP menu

### DIFF
--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -14,7 +14,6 @@ from utils.keyboard_utils import (
     get_missions_keyboard,
 )
 from keyboards.vip_main_kb import get_vip_main_kb
-from keyboards.vip_game_kb import get_game_menu_kb
 from utils.messages import BOT_MESSAGES
 from utils.message_utils import get_profile_message
 from services.subscription_service import SubscriptionService
@@ -39,7 +38,7 @@ async def vip_menu(message: Message, session: AsyncSession):
         return
     await send_menu(
         message,
-        "Bienvenido al Diván de Diana",
+        BOT_MESSAGES["start_welcome_returning_user"],
         get_vip_main_kb(),
         session,
         "vip_main",
@@ -60,7 +59,7 @@ async def vip_menu_cb(callback: CallbackQuery, session: AsyncSession):
         return
     await update_menu(
         callback,
-        "Bienvenido al Diván de Diana",
+        BOT_MESSAGES["start_welcome_returning_user"],
         get_vip_main_kb(),
         session,
         "vip_main",
@@ -190,9 +189,9 @@ async def vip_game(callback: CallbackQuery, session: AsyncSession):
         return
     await callback.message.edit_text(
         BOT_MESSAGES["start_welcome_returning_user"],
-        reply_markup=get_game_menu_kb(),
+        reply_markup=get_vip_main_kb(),
     )
-    await set_user_menu_state(session, callback.from_user.id, "root")
+    await set_user_menu_state(session, callback.from_user.id, "vip_main")
     await callback.answer()
 
 

--- a/mybot/keyboards/vip_main_kb.py
+++ b/mybot/keyboards/vip_main_kb.py
@@ -1,10 +1,14 @@
-from aiogram.utils.keyboard import InlineKeyboardBuilder
+"""Keyboard helpers for VIP menus."""
+
+from utils.keyboard_utils import get_main_menu_keyboard
 
 
 def get_vip_main_kb():
-    """Return the root VIP menu keyboard."""
-    builder = InlineKeyboardBuilder()
-    builder.button(text="📄 Mi Suscripción", callback_data="vip_subscription")
-    builder.button(text="🎮 Juego Kinky", callback_data="vip_game")
-    builder.adjust(1)
-    return builder.as_markup()
+    """Return the default VIP menu keyboard.
+
+    This mirrors the menu previously shown under "Juego Kinky" so that
+    VIP users immediately see all options like Mi Suscripción, Perfil y
+    Misiones al entrar.
+    """
+
+    return get_main_menu_keyboard()

--- a/mybot/utils/menu_utils.py
+++ b/mybot/utils/menu_utils.py
@@ -6,6 +6,7 @@ from database.models import set_user_menu_state
 from utils.user_roles import get_user_role
 from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.vip_main_kb import get_vip_main_kb
+from utils.messages import BOT_MESSAGES
 from keyboards.subscription_kb import get_free_main_menu_kb
 
 
@@ -14,7 +15,11 @@ def _menu_details(role: str):
     if role == "admin":
         return "Panel de Administración", get_admin_main_kb(), "admin_main"
     if role == "vip":
-        return "Bienvenido al Diván de Diana", get_vip_main_kb(), "vip_main"
+        return (
+            BOT_MESSAGES["start_welcome_returning_user"],
+            get_vip_main_kb(),
+            "vip_main",
+        )
     return "Bienvenido a los Kinkys", get_free_main_menu_kb(), "free_main"
 
 # Cache to store the latest menu message for each user


### PR DESCRIPTION
## Summary
- show the game menu directly when VIP users open their menu
- reuse the main game keyboard for VIP entry

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68588e825d5c83299bfd3ea9b5a85f88