### PR TITLE
Fix TypeError when registering callback states

### DIFF
--- a/mybot/handlers/admin/config_menu.py
+++ b/mybot/handlers/admin/config_menu.py
@@ -1,4 +1,5 @@
 from aiogram import Router, F
+from aiogram.filters import StateFilter
 from aiogram.types import CallbackQuery, Message
 from aiogram.enums.chat_type import ChatType
 from aiogram import Bot
@@ -125,8 +126,12 @@ async def set_vip_reactions(message: Message, state: FSMContext, session: AsyncS
     await message.answer(text, reply_markup=get_reaction_confirm_kb())
 
 
+
 @router.callback_query(
-    (AdminConfigStates.waiting_for_reaction_buttons | AdminConfigStates.waiting_for_reaction_points),
+    StateFilter(
+        AdminConfigStates.waiting_for_reaction_buttons,
+        AdminConfigStates.waiting_for_reaction_points,
+    ),
     F.data == "save_reactions",
 )
 async def save_reaction_buttons_callback(callback: CallbackQuery, state: FSMContext, session: AsyncSession):


### PR DESCRIPTION
## Summary
- import `StateFilter` from Aiogram
- use `StateFilter` in admin config router to handle multiple states

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c5e5e4bc8329b32e409ef638350d