### PR TITLE
Fix state filter usage in config menu

### DIFF
--- a/mybot/handlers/admin/config_menu.py
+++ b/mybot/handlers/admin/config_menu.py
@@ -129,8 +129,10 @@ async def set_vip_reactions(message: Message, state: FSMContext, session: AsyncS
 
 
 @router.callback_query(
-    (AdminConfigStates.waiting_for_reaction_buttons | AdminConfigStates.waiting_for_reaction_points),
-
+    StateFilter(
+        AdminConfigStates.waiting_for_reaction_buttons,
+        AdminConfigStates.waiting_for_reaction_points,
+    ),
     F.data == "save_reactions",
 )
 async def save_reaction_buttons_callback(callback: CallbackQuery, state: FSMContext, session: AsyncSession):


### PR DESCRIPTION
## Summary
- handle multiple admin config states properly in `config_menu`

## Testing
- `python -m py_compile mybot/handlers/admin/config_menu.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858f28732fc83299864a948299172f7