### PR TITLE
Implement VIP tariff management

### DIFF
--- a/mybot/keyboards/tarifas_kb.py
+++ b/mybot/keyboards/tarifas_kb.py
@@ -1,10 +1,28 @@
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
-def get_tarifas_kb():
+from typing import Sequence
+from database.models import Tariff
+
+
+def get_tarifas_kb(tariffs: Sequence[Tariff] | None = None):
+    """Keyboard listing existing tariffs with management options."""
     builder = InlineKeyboardBuilder()
+    if tariffs:
+        for t in tariffs:
+            builder.button(text=t.name, callback_data=f"tariff_{t.id}")
     builder.button(text="➕ Nueva Tarifa", callback_data="tarifa_new")
     builder.button(text="🔙 Volver", callback_data="vip_config")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_tariff_options_kb(tariff_id: int):
+    """Keyboard with options for a specific tariff."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="✏️ Editar", callback_data=f"edit_tariff_{tariff_id}")
+    builder.button(text="🗑 Eliminar", callback_data=f"delete_tariff_{tariff_id}")
+    builder.button(text="🔙 Volver", callback_data="config_tarifas")
     builder.adjust(1)
     return builder.as_markup()
 

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -41,6 +41,9 @@ class AdminTariffStates(StatesGroup):
     waiting_for_tariff_duration = State()
     waiting_for_tariff_price = State()
     waiting_for_tariff_name = State()
+    editing_tariff_duration = State()
+    editing_tariff_price = State()
+    editing_tariff_name = State()
 
 
 class AdminUserStates(StatesGroup):


### PR DESCRIPTION
## Summary
- extend tariff keyboards with tariff list and options
- allow editing tariffs via new FSM states
- refresh tariff list after updates or deletions

## Testing
- `python -m py_compile mybot/handlers/admin/subscription_plans.py mybot/keyboards/tarifas_kb.py mybot/utils/admin_state.py`
- `python -m py_compile mybot/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6858fa08f7388329bfdec7dbc6314c48