### PR TITLE
Fix reaction notification for inline buttons

### DIFF
--- a/mybot/handlers/interactive_post.py
+++ b/mybot/handlers/interactive_post.py
@@ -45,4 +45,8 @@ async def handle_interactive_post_callback(
     points = points_list[idx] if idx < len(points_list) else 0.0
     await PointService(session).add_points(callback.from_user.id, points, bot=bot)
     await callback.answer(BOT_MESSAGES["reaction_registered_points"].format(points=points))
+    await bot.send_message(
+        callback.from_user.id,
+        BOT_MESSAGES["reaction_registered_points"].format(points=points),
+    )
 


### PR DESCRIPTION
## Summary
- notify users in private chat when reacting to interactive posts

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685904375e508329894d05125ba15e4d