### PR TITLE
Add reaction count display for VIP posts

### DIFF
--- a/mybot/handlers/interactive_post.py
+++ b/mybot/handlers/interactive_post.py
@@ -43,6 +43,15 @@ async def handle_interactive_post_callback(
     except (ValueError, IndexError):
         pass
     points = points_list[idx] if idx < len(points_list) else 0.0
-    await PointService(session).add_points(callback.from_user.id, points, bot=bot)
-    await callback.answer(BOT_MESSAGES["reaction_registered_points"].format(points=points))
-
+    await PointService(session).add_points(
+        callback.from_user.id,
+        points,
+        bot=bot,
+    )
+    await service.update_reaction_markup(
+        callback.message.chat.id,
+        message_id,
+    )
+    await callback.answer(
+        BOT_MESSAGES["reaction_registered_points"].format(points=points)
+    )

--- a/mybot/keyboards/common.py
+++ b/mybot/keyboards/common.py
@@ -12,12 +12,16 @@ def get_back_kb(callback_data: str = "admin_back"):
 
 
 def get_interactive_post_kb(
-    message_id: int, buttons: list[str] | None = None
+    message_id: int,
+    buttons: list[str] | None = None,
+    counts: dict[str, int] | None = None,
 ) -> InlineKeyboardMarkup:
     """Keyboard with reaction buttons for channel posts."""
     texts = buttons if buttons else DEFAULT_REACTION_BUTTONS
     builder = InlineKeyboardBuilder()
     for idx, text in enumerate(texts[:10]):
-        builder.button(text=text, callback_data=f"ip_r{idx}_{message_id}")
+        count = counts.get(f"r{idx}", 0) if counts else 0
+        display = f"{text} {count}"
+        builder.button(text=display, callback_data=f"ip_r{idx}_{message_id}")
     builder.adjust(len(texts[:10]))
     return builder.as_markup()

--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from aiogram import Bot
 from aiogram.types import Message, ReactionTypeEmoji
-from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError, TelegramAPIError
+from aiogram.exceptions import (
+    TelegramBadRequest,
+    TelegramForbiddenError,
+    TelegramAPIError,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, func
 
 from .config_service import ConfigService
 from database.models import ButtonReaction
@@ -46,12 +50,17 @@ class MessageService:
         try:
             buttons = await config.get_reaction_buttons()
             sent = await self.bot.send_message(
-                channel_id, text, reply_markup=get_interactive_post_kb(0, buttons)
+                channel_id,
+                text,
+                reply_markup=get_interactive_post_kb(0, buttons),
             )
+            counts = await self.get_reaction_counts(sent.message_id)
             await self.bot.edit_message_reply_markup(
                 channel_id,
                 sent.message_id,
-                reply_markup=get_interactive_post_kb(sent.message_id, buttons),
+                reply_markup=get_interactive_post_kb(
+                    sent.message_id, buttons, counts
+                ),
             )
             if channel_type == "vip":
                 vip_reactions = await config.get_vip_reactions()
@@ -85,3 +94,36 @@ class MessageService:
         await self.session.commit()
         await self.session.refresh(reaction)
         return reaction
+
+    async def get_reaction_counts(self, message_id: int) -> dict[str, int]:
+        """Return reaction counts for the given message."""
+        stmt = (
+            select(
+                ButtonReaction.reaction_type,
+                func.count(ButtonReaction.id),
+            )
+            .where(ButtonReaction.message_id == message_id)
+            .group_by(ButtonReaction.reaction_type)
+        )
+        result = await self.session.execute(stmt)
+        return {row[0]: row[1] for row in result.all()}
+
+    async def update_reaction_markup(
+        self, chat_id: int, message_id: int
+    ) -> None:
+        """Update the inline keyboard with reaction counts."""
+        counts = await self.get_reaction_counts(message_id)
+        config = ConfigService(self.session)
+        buttons = await config.get_reaction_buttons()
+        try:
+            await self.bot.edit_message_reply_markup(
+                chat_id,
+                message_id,
+                reply_markup=get_interactive_post_kb(
+                    message_id,
+                    buttons,
+                    counts,
+                ),
+            )
+        except TelegramBadRequest:
+            pass


### PR DESCRIPTION
## Summary
- display reaction counts in `get_interactive_post_kb`
- update `MessageService` to manage reaction counts and update markup
- update reaction handler to refresh counts after each reaction
- fix flake8 issues

## Testing
- `python -m py_compile mybot/keyboards/common.py mybot/services/message_service.py mybot/handlers/interactive_post.py`
- `flake8 mybot/keyboards/common.py mybot/services/message_service.py mybot/handlers/interactive_post.py`


------
https://chatgpt.com/codex/tasks/task_e_6858fc4865448329b94e81412ebd4664