### PR TITLE
Fix syntax errors in message service

### DIFF
--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -105,7 +105,7 @@ class MessageService:
             )
 
             .where(ButtonReaction.message_id == message_id)
-            .
+            .group_by(ButtonReaction.reaction_type)
         )
         result = await self.session.execute(stmt)
         return {row[0]: row[1] for row in result.all()}
@@ -128,7 +128,6 @@ class MessageService:
                     buttons,
                     counts,
                 ),
-=
             )
         except TelegramBadRequest:
             pass


### PR DESCRIPTION
## Summary
- fix typo in SQL query construction
- clean up stray `=` in inline markup update

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check mybot/services/message_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68590fab7d948329b389a50ce1469e6d