### PR TITLE
Implement channel-specific reaction settings

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -298,6 +298,8 @@ class Channel(AsyncAttrs, Base):
     __tablename__ = "channels"
     id = Column(BigInteger, primary_key=True)  # Telegram chat ID
     title = Column(String, nullable=True)
+    reactions = Column(String, nullable=True)
+    reaction_points = Column(String, nullable=True)
 
 
 class PendingChannelRequest(AsyncAttrs, Base):

--- a/mybot/handlers/free_channel_admin.py
+++ b/mybot/handlers/free_channel_admin.py
@@ -11,6 +11,7 @@ from utils.user_roles import is_admin
 from utils.menu_manager import menu_manager
 from services.free_channel_service import FreeChannelService
 from services.config_service import ConfigService
+from services.channel_service import ChannelService
 from keyboards.common import get_interactive_post_kb
 from keyboards.free_channel_admin_kb import (
     get_free_channel_admin_kb,
@@ -336,22 +337,25 @@ async def confirm_and_send_post(callback: CallbackQuery, state: FSMContext, sess
     data = await state.get_data()
     
     free_service = FreeChannelService(session, callback.bot)
-    
+
     config = ConfigService(session)
-    buttons = await config.get_reaction_buttons()
+    channel_id = await config.get_free_channel_id()
+    channel_service = ChannelService(session)
+    buttons = await channel_service.get_reactions(channel_id)
     sent_message = await free_service.send_message_to_channel(
         text=data.get("post_text", ""),
         protect_content=protect_content,
-        reply_markup=get_interactive_post_kb(0, buttons),
+        reply_markup=get_interactive_post_kb(0, buttons, channel_id),
         media_files=data.get("media_files", [])
     )
 
     if sent_message:
-        channel_id = await config.get_free_channel_id()
         await callback.bot.edit_message_reply_markup(
             channel_id,
             sent_message.message_id,
-            reply_markup=get_interactive_post_kb(sent_message.message_id, buttons),
+            reply_markup=get_interactive_post_kb(
+                sent_message.message_id, buttons, channel_id
+            ),
         )
     
     if sent_message:

--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -3,7 +3,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 def get_admin_config_kb():
     builder = InlineKeyboardBuilder()
-    builder.button(text="📝 Configurar Reacciones", callback_data="config_reaction_buttons")
+    builder.button(text="💬 Configurar Reacciones", callback_data="config_channel_reactions")
     builder.button(text="🤖 Reacciones VIP", callback_data="config_vip_reactions")
     builder.button(text="➕ Agregar canales", callback_data="config_add_channels")
     builder.button(text="⏱️ Schedulers", callback_data="config_scheduler")
@@ -48,6 +48,15 @@ def get_reaction_confirm_kb():
     """Keyboard shown while configuring reaction emojis."""
     builder = InlineKeyboardBuilder()
     builder.button(text="✅ Aceptar", callback_data="save_reactions")
+    builder.button(text="🔙 Volver", callback_data="admin_config")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_reaction_channel_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Canal VIP", callback_data="reaction_channel_vip")
+    builder.button(text="Canal FREE", callback_data="reaction_channel_free")
     builder.button(text="🔙 Volver", callback_data="admin_config")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/keyboards/common.py
+++ b/mybot/keyboards/common.py
@@ -12,12 +12,18 @@ def get_back_kb(callback_data: str = "admin_back"):
 
 
 def get_interactive_post_kb(
-    message_id: int, buttons: list[str] | None = None
+    message_id: int,
+    buttons: list[str] | None = None,
+    channel_id: int | None = None,
 ) -> InlineKeyboardMarkup:
     """Keyboard with reaction buttons for channel posts."""
     texts = buttons if buttons else DEFAULT_REACTION_BUTTONS
     builder = InlineKeyboardBuilder()
     for idx, text in enumerate(texts[:10]):
-        builder.button(text=text, callback_data=f"ip_r{idx}_{message_id}")
+        if channel_id is not None:
+            cb_data = f"ip_{channel_id}_r{idx}_{message_id}"
+        else:
+            cb_data = f"ip_r{idx}_{message_id}"
+        builder.button(text=text, callback_data=cb_data)
     builder.adjust(len(texts[:10]))
     return builder.as_markup()

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -65,6 +65,9 @@ class AdminConfigStates(StatesGroup):
 
     waiting_for_reaction_buttons = State()
     waiting_for_reaction_points = State()
+    waiting_for_reaction_channel = State()
+    waiting_for_channel_reaction_buttons = State()
+    waiting_for_channel_reaction_points = State()
     waiting_for_vip_reactions = State()
     waiting_for_channel_choice = State()
     waiting_for_channel_interval = State()


### PR DESCRIPTION
## Summary
- allow storing custom reactions per channel
- wire up channel reaction configuration states in admin panel
- pass channel id in interactive post callbacks
- update utilities and services for new reaction logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685903ea7ca883299fc2704a20cd3b83