### PR TITLE
Add inline minigames menu

### DIFF
--- a/mybot/handlers/free_user.py
+++ b/mybot/handlers/free_user.py
@@ -11,6 +11,7 @@ from keyboards.subscription_kb import get_free_main_menu_kb, get_vip_explore_kb
 from keyboards.packs_kb import get_packs_list_kb, get_pack_detail_kb
 from utils.messages import BOT_MESSAGES
 from utils.keyboard_utils import get_back_keyboard
+from keyboards.minigames_kb import get_minigames_kb
 from utils.notify_admins import notify_admins
 
 router = Router()
@@ -106,7 +107,7 @@ async def cb_free_game(callback: CallbackQuery, session: AsyncSession):
     await menu_manager.update_menu(
         callback,
         BOT_MESSAGES.get("FREE_GAME_TEXT", "Mini juego"),
-        get_back_keyboard("free_main_menu"),
+        get_minigames_kb("free_main_menu"),
         session,
         "free_game",
     )

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -13,6 +13,7 @@ from utils.keyboard_utils import (
     get_main_menu_keyboard,
     get_missions_keyboard,
 )
+from keyboards.minigames_kb import get_minigames_kb
 from keyboards.vip_main_kb import get_vip_main_kb
 from utils.messages import BOT_MESSAGES
 from utils.message_utils import get_profile_message
@@ -256,6 +257,24 @@ async def gain_points(callback: CallbackQuery, session: AsyncSession):
             "Participa en misiones y actividades para ganar puntos."
         ),
         reply_markup=get_back_keyboard("vip_game")
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "game_minigames")
+async def game_minigames(callback: CallbackQuery, session: AsyncSession):
+    if await get_user_role(callback.bot, callback.from_user.id, session=session) != "vip":
+        await callback.answer(
+            BOT_MESSAGES.get(
+                "vip_members_only",
+                "Esta sección está disponible solo para miembros VIP."
+            ),
+            show_alert=True,
+        )
+        return
+
+    await callback.message.edit_text(
+        "Elige un minijuego:", reply_markup=get_minigames_kb("vip_game")
     )
     await callback.answer()
 

--- a/mybot/keyboards/__init__.py
+++ b/mybot/keyboards/__init__.py
@@ -1,0 +1,1 @@
+from .minigames_kb import get_minigames_kb

--- a/mybot/keyboards/minigames_kb.py
+++ b/mybot/keyboards/minigames_kb.py
@@ -1,0 +1,11 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+
+
+def get_minigames_kb(back_callback: str) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="🎲 Tirar Dado", callback_data="play_dice")
+    builder.button(text="❓ Trivia", callback_data="play_trivia")
+    builder.button(text="🔙 Volver", callback_data=back_callback)
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/keyboards/vip_game_kb.py
+++ b/mybot/keyboards/vip_game_kb.py
@@ -5,5 +5,6 @@ def get_game_menu_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="Mi perfil", callback_data="game_profile")
     builder.button(text="Ganar puntos", callback_data="gain_points")
+    builder.button(text="Minijuegos", callback_data="game_minigames")
     builder.adjust(1)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- create `get_minigames_kb` keyboard
- allow free game menu to show minigame buttons
- handle `play_dice` and `play_trivia` callbacks
- expose minigames from VIP game menu

## Testing
- `python -m py_compile mybot/keyboards/minigames_kb.py mybot/handlers/free_user.py mybot/handlers/minigames.py mybot/keyboards/vip_game_kb.py mybot/handlers/vip/menu.py`


------
https://chatgpt.com/codex/tasks/task_e_68592e5e64488329bac7092bfb47cea2