### PR TITLE
Integrate minigames into VIP menu

### DIFF
--- a/mybot/handlers/minigames.py
+++ b/mybot/handlers/minigames.py
@@ -37,6 +37,18 @@ async def play_dice(message: Message, session: AsyncSession, bot: Bot):
     await PointService(session).add_points(message.from_user.id, score, bot=bot)
     await message.answer(BOT_MESSAGES.get("dice_points", "Ganaste {points} puntos").format(points=score))
 
+
+@router.callback_query(F.data == "play_dice")
+async def play_dice_cb(callback: CallbackQuery, session: AsyncSession, bot: Bot):
+    config = ConfigService(session)
+    if (await config.get_value("minigames_enabled")) == "false":
+        return await callback.answer(BOT_MESSAGES.get("minigames_disabled", "Minijuegos deshabilitados."), show_alert=True)
+    dice_msg = await bot.send_dice(callback.message.chat.id)
+    score = dice_msg.dice.value
+    await PointService(session).add_points(callback.from_user.id, score, bot=bot)
+    await callback.message.answer(BOT_MESSAGES.get("dice_points", "Ganaste {points} puntos").format(points=score))
+    await callback.answer()
+
 @router.message(F.text.regexp("/trivia"))
 async def send_trivia(message: Message, session: AsyncSession):
     config = ConfigService(session)
@@ -49,6 +61,21 @@ async def send_trivia(message: Message, session: AsyncSession):
         for i, opt in enumerate(q["opts"])
     ]
     await message.answer(q["q"], reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons))
+
+
+@router.callback_query(F.data == "play_trivia")
+async def send_trivia_cb(callback: CallbackQuery, session: AsyncSession):
+    config = ConfigService(session)
+    if (await config.get_value("minigames_enabled")) == "false":
+        await callback.answer(BOT_MESSAGES.get("minigames_disabled", "Minijuegos deshabilitados."), show_alert=True)
+        return
+    q = random.choice(TRIVIA)
+    buttons = [
+        [InlineKeyboardButton(text=opt, callback_data="trivia_correct" if i == q["answer"] else "trivia_wrong")]
+        for i, opt in enumerate(q["opts"])
+    ]
+    await callback.message.answer(q["q"], reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons))
+    await callback.answer()
 
 @router.callback_query(F.data.in_({"trivia_correct", "trivia_wrong"}))
 async def trivia_answer(callback: CallbackQuery, session: AsyncSession, bot: Bot):

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -176,6 +176,25 @@ async def vip_badges(callback: CallbackQuery, session: AsyncSession):
     await callback.answer()
 
 
+@router.callback_query(F.data == "vip_minigames")
+async def vip_minigames(callback: CallbackQuery, session: AsyncSession):
+    if await get_user_role(callback.bot, callback.from_user.id, session=session) != "vip":
+        await callback.answer(
+            BOT_MESSAGES.get(
+                "vip_members_only",
+                "Esta sección está disponible solo para miembros VIP.",
+            ),
+            show_alert=True,
+        )
+        return
+    from keyboards.minigames_kb import get_minigames_kb
+
+    await callback.message.edit_text(
+        "Selecciona un minijuego:", reply_markup=get_minigames_kb()
+    )
+    await callback.answer()
+
+
 @router.callback_query(F.data == "vip_game")
 async def vip_game(callback: CallbackQuery, session: AsyncSession):
     if await get_user_role(callback.bot, callback.from_user.id, session=session) != "vip":

--- a/mybot/keyboards/minigames_kb.py
+++ b/mybot/keyboards/minigames_kb.py
@@ -1,0 +1,10 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_minigames_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="🎲 Dados", callback_data="play_dice")
+    builder.button(text="❓ Trivia", callback_data="play_trivia")
+    builder.button(text="🔙 Volver", callback_data="vip_menu")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -18,6 +18,7 @@ def get_main_menu_keyboard():
         [InlineKeyboardButton(text="🎁 Recompensas", callback_data="menu:rewards")],
         [InlineKeyboardButton(text="🏛️ Subastas", callback_data="auction_main")],
         [InlineKeyboardButton(text="🏆 Ranking", callback_data="menu:ranking")],
+        [InlineKeyboardButton(text="🕹 Minijuegos", callback_data="vip_minigames")],
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 


### PR DESCRIPTION
## Summary
- add a new inline keyboard for minigames
- include a **Minijuegos** option in the VIP main menu
- create VIP handler to show minigame choices
- allow playing dice and trivia from buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68594e1e087c832987e1e9729c4fc3bc