### PR TITLE
Implement VIP membership validation caching

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -59,6 +59,10 @@ class User(AsyncAttrs, Base):
     # Channel reactions tracking
     channel_reactions = Column(JSON, default={})  # {'message_id': True}
 
+    # VIP membership validation caching
+    is_vip = Column(Boolean, default=False)
+    vip_last_checked = Column(DateTime, nullable=True)
+
 
 class Reward(AsyncAttrs, Base):
     """Rewards unlocked by reaching a number of points."""

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -62,6 +62,13 @@ async def cmd_start(message: Message, session: AsyncSession):
         if updated:
             await session.commit()
             logger.info(f"Updated user info: {user_id}")
+
+    # Validate VIP membership on each /start
+    from utils.user_roles import is_vip_member
+    try:
+        await is_vip_member(message.bot, user_id, session=session, force_check=True)
+    except Exception as e:
+        logger.error(f"VIP validation failed for {user_id}: {e}")
     
     # Check if this is an admin
     if is_admin(user_id):

--- a/mybot/handlers/vip/gamification.py
+++ b/mybot/handlers/vip/gamification.py
@@ -78,7 +78,11 @@ async def menu_callback_handler(callback: CallbackQuery, session: AsyncSession):
         )
         return
     
+    from utils.user_roles import is_vip_member
+
     try:
+        # Force membership validation for important action
+        await is_vip_member(callback.bot, user_id, session=session, force_check=True)
         menu_type = callback.data.split(":")[1]
         text, keyboard = await menu_factory.create_menu(menu_type, user_id, session, callback.bot)
         await menu_manager.update_menu(callback, text, keyboard, session, menu_type)
@@ -135,7 +139,10 @@ async def handle_claim_reward_callback(callback: CallbackQuery, session: AsyncSe
         await callback.answer("Esta función está disponible solo para miembros VIP.", show_alert=True)
         return
     
+    from utils.user_roles import is_vip_member
+
     try:
+        await is_vip_member(callback.bot, user_id, session=session, force_check=True)
         reward_id = int(callback.data.split("_")[-1])
         reward_service = RewardService(session)
         success, message = await reward_service.claim_reward(user_id, reward_id)
@@ -201,8 +208,11 @@ async def handle_complete_mission_callback(callback: CallbackQuery, session: Asy
         await callback.answer("Esta función está disponible solo para miembros VIP.", show_alert=True)
         return
     
+    from utils.user_roles import is_vip_member
+
     try:
-        mission_id = callback.data[len("complete_mission_"):]
+        await is_vip_member(callback.bot, user_id, session=session, force_check=True)
+        mission_id = callback.data[len("complete_mission_") :]
         mission_service = MissionService(session)
         user = await session.get(User, user_id)
         mission = await mission_service.get_mission_by_id(mission_id)

--- a/mybot/utils/user_roles.py
+++ b/mybot/utils/user_roles.py
@@ -22,38 +22,51 @@ def is_admin(user_id: int) -> bool:
     return user_id in ADMIN_IDS
 
 
-async def is_vip_member(bot: Bot, user_id: int, session: AsyncSession | None = None) -> bool:
-    """Check if the user should be considered a VIP."""
+async def is_vip_member(
+    bot: Bot,
+    user_id: int,
+    session: AsyncSession | None = None,
+    *,
+    force_check: bool = False,
+) -> bool:
+    """Check if the user should be considered a VIP.
+
+    Membership is cached in the ``users`` table using the ``is_vip`` and
+    ``vip_last_checked`` fields. If the last validation was less than
+    30 minutes ago and ``force_check`` is False, the cached value is used.
+    """
     from services.config_service import ConfigService
 
-    # First check database subscription status
+    now = datetime.utcnow()
+    db_value: bool | None = None
+    user: User | None = None
+
     if session:
         try:
-            # Check if user has active VIP subscription in database
             user = await session.get(User, user_id)
-            if user and user.role == "vip":
-                # Check if subscription is still valid
-                if user.vip_expires_at is None or user.vip_expires_at > datetime.utcnow():
-                    logger.debug(f"User {user_id} is VIP via database record")
-                    return True
-                else:
-                    # Subscription expired, update role
-                    user.role = "free"
-                    await session.commit()
-                    logger.info(f"User {user_id} VIP subscription expired, updated to free")
-            
-            # Also check VipSubscription table
+            if user and not force_check and user.vip_last_checked and (now - user.vip_last_checked) < timedelta(minutes=30):
+                logger.debug(
+                    f"Using cached VIP status for {user_id}: {user.is_vip}"
+                )
+                return bool(user.is_vip)
+
+            # Preserve possible subscription based status
+            if user and user.role == "vip" and (
+                user.vip_expires_at is None or user.vip_expires_at > now
+            ):
+                db_value = True
+
             stmt = select(VipSubscription).where(VipSubscription.user_id == user_id)
             result = await session.execute(stmt)
             subscription = result.scalar_one_or_none()
-            if subscription:
-                if subscription.expires_at is None or subscription.expires_at > datetime.utcnow():
-                    logger.debug(f"User {user_id} is VIP via subscription table")
-                    return True
-                else:
-                    logger.debug(f"User {user_id} subscription expired")
+            if subscription and (
+                subscription.expires_at is None or subscription.expires_at > now
+            ):
+                db_value = True
         except Exception as e:
-            logger.error(f"Error checking VIP status in database for user {user_id}: {e}")
+            logger.error(
+                f"Error checking VIP status in database for user {user_id}: {e}"
+            )
 
     # Fallback to channel membership check
     vip_channel_id = VIP_CHANNEL_ID
@@ -73,11 +86,23 @@ async def is_vip_member(bot: Bot, user_id: int, session: AsyncSession | None = N
     try:
         member = await bot.get_chat_member(vip_channel_id, user_id)
         is_member = member.status in {"member", "administrator", "creator"}
-        logger.debug(f"User {user_id} channel membership check: {is_member} (status: {member.status})")
-        return is_member
+        logger.debug(
+            f"User {user_id} channel membership check: {is_member} (status: {member.status})"
+        )
+        if session and user:
+            user.is_vip = is_member
+            user.vip_last_checked = now
+            await session.commit()
+        return is_member or bool(db_value)
     except Exception as e:
-        logger.warning(f"Error checking channel membership for user {user_id}: {e}")
-        return False
+        logger.warning(
+            f"Error checking channel membership for user {user_id}: {e}"
+        )
+        if session and user:
+            user.is_vip = False
+            user.vip_last_checked = now
+            await session.commit()
+        return bool(db_value)
 
 
 async def get_points_multiplier(bot: Bot, user_id: int, session: AsyncSession | None = None) -> int:


### PR DESCRIPTION
## Summary
- add is_vip and vip_last_checked fields to User model
- cache VIP membership status in `is_vip_member`
- record VIP validation on `/start`
- force validation when claiming rewards or completing missions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859539975dc83299ab92bc77a4eb4a9