### PR TITLE
Add table recreation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ export VIP_SCHEDULER_INTERVAL="3600"    # Segundos entre verificaciones VIP
 ```bash
 python scripts/init_db.py
 python scripts/migrate_vip_columns.py  # Agrega columnas is_vip y vip_last_checked
+python scripts/recreate_users_table.py  # Reinicia la tabla de usuarios
 ```
 
 ### 4. Ejecutar el Bot

--- a/scripts/recreate_users_table.py
+++ b/scripts/recreate_users_table.py
@@ -1,0 +1,22 @@
+import asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from mybot.utils.config import Config
+from mybot.database.models import User
+
+
+async def main() -> None:
+    """Drop the existing users table and recreate it."""
+    engine = create_async_engine(Config.DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        # Drop only the users table to preserve other data
+        await conn.execute(text("DROP TABLE IF EXISTS users"))
+        # Recreate the table using the current model definition
+        await conn.run_sync(User.__table__.create)
+    await engine.dispose()
+    print("Users table recreated.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add script to recreate `users` table with latest columns
- document running the script in the setup steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685959172928832985e7366f30f0b42d