### PR TITLE
Organize messages into categories

### DIFF
--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -94,9 +94,14 @@ async def start_with_token(message: Message, command: CommandObject, session: As
             logger.error(f"Failed to create VIP invite link: {e}")
             invite_link = None
 
-    # Send welcome message with invite link
+    # Mensaje inicial de la Señorita Kinky
+    await message.answer(
+        BOT_MESSAGES["vip_first_welcome"]
+    )
+
+    # Mensaje posterior del Mayordomo con detalles e invitación
     if invite_link:
-        welcome_msg = (
+        butler_msg = (
             f"🎉 ¡Bienvenido al VIP!\n\n"
             f"Tu suscripción VIP ha sido activada por {duration} días.\n"
             f"Expira el: {expires_at.strftime('%d/%m/%Y %H:%M')}\n\n"
@@ -104,14 +109,14 @@ async def start_with_token(message: Message, command: CommandObject, session: As
             f"⚠️ Este enlace es personal y expira en 24 horas."
         )
     else:
-        welcome_msg = (
+        butler_msg = (
             f"🎉 ¡Suscripción VIP activada!\n\n"
             f"Duración: {duration} días\n"
             f"Expira el: {expires_at.strftime('%d/%m/%Y %H:%M')}\n\n"
-            f"Usa /vip_menu para acceder a tus beneficios VIP."
+            f"Usa /vip_menu para acceder a sus beneficios VIP."
         )
 
-    await message.answer(welcome_msg)
+    await message.answer(butler_msg)
     logger.info(f"VIP activation completed for user {user_id}")
 
     # Clear role cache again to ensure the new role is detected immediately

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -1,5 +1,33 @@
-# utils/messages.py
-BOT_MESSAGES = {
+"""Centralized text resources for the bot grouped by category."""
+
+# ---------------------------------------------------------------------------
+# Mensajes del Mayordomo del Diván
+# ---------------------------------------------------------------------------
+BUTLER_MESSAGES = {
+    "vip_members_only": "Esta sección está disponible solo para miembros VIP.",
+    "profile_not_registered": "Parece que aún no has comenzado tu recorrido. Usa /start para dar tu primer paso.",
+    "back_to_main_menu": "Has regresado al centro del Diván. Elige por dónde seguir explorando.",
+    "unrecognized_command_text": "Comando no reconocido. Aquí está el menú principal:",
+    "confirm_purchase_message": "¿Estás segur@ de que quieres canjear {reward_name} por {reward_cost} puntos?",
+    "purchase_cancelled_message": "Compra cancelada. Puedes seguir explorando otras recompensas.",
+    "gain_points_instructions": "Puedes ganar puntos completando misiones y participando en las actividades del canal.",
+    "enter_reward_name": "Ingresa el nombre de la recompensa:",
+    "enter_reward_points": "¿Cuántos puntos se requieren?",
+    "enter_reward_description": "Agrega una descripción (opcional):",
+    "select_reward_type": "Selecciona el tipo de recompensa:",
+    "reward_created": "✅ Recompensa creada.",
+    "reward_deleted": "❌ Recompensa eliminada.",
+    "reward_updated": "✅ Recompensa actualizada.",
+    "invalid_number": "Ingresa un número válido.",
+    "level_created": "✅ Nivel creado correctamente.",
+    "level_updated": "✅ Nivel actualizado.",
+    "level_deleted": "❌ Nivel eliminado.",
+}
+
+# ---------------------------------------------------------------------------
+# Mensajes de la Señorita Kinky
+# ---------------------------------------------------------------------------
+KINKY_MESSAGES = {
     "start_welcome_new_user": (
         "🌙 Bienvenid@ a *El Diván de Diana*…\n\n"
         "Aquí cada gesto, cada decisión y cada paso que das, suma. Con cada interacción, te adentras más en *El Juego del Diván*.\n\n"
@@ -10,8 +38,25 @@ BOT_MESSAGES = {
         "Tu lugar sigue aquí. Tus puntos también... y hay nuevas sorpresas esperándote.\n\n"
         "¿List@ para continuar *El Juego del Diván*?"
     ),
-    "vip_members_only": "Esta sección está disponible solo para miembros VIP.",
-    "profile_not_registered": "Parece que aún no has comenzado tu recorrido. Usa /start para dar tu primer paso.",
+    "reward_claim_success": "🎉 ¡Recompensa reclamada!",
+    "level_up_notification": "🎉 ¡Subiste a Nivel {level}: {level_name}! {reward}",
+    "special_level_reward": "✨ Recompensa especial por alcanzar el nivel {level}! {reward}",
+    "daily_gift_received": "🎁 Recibiste {points} puntos del regalo diario!",
+    "PACK_INTEREST_REPLY": "💌 ¡Gracias! Recibí tu interés. Me pondré en contacto contigo muy pronto. O si no quieres esperar escríbeme directo a mi chat privado en ,,@DianaKinky ",
+    "VIP_INTEREST_REPLY": (
+        "💌 ¡Gracias! Recibí tu interés. Me pondré en contacto contigo muy pronto. "
+        "O si no quieres esperar escríbeme directo a mi chat privado en ,,@DianaKinky "
+    ),
+    "vip_first_welcome": (
+        "💖 Bienvenido al VIP, cariño. Gracias por acompañarme en este rincón tan exclusivo."\
+        " Prepárate para disfrutar como nunca antes... ahora te dejo en manos del Mayordomo del Diván."
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Textos de menús y opciones generales
+# ---------------------------------------------------------------------------
+MENU_MESSAGES = {
     "profile_title": "🛋️ *Tu rincón en El Diván de Diana*",
     "profile_points": "📌 *Puntos acumulados:* `{user_points}`",
     "profile_level": "🎯 *Nivel actual:* `{user_level}`",
@@ -23,30 +68,13 @@ BOT_MESSAGES = {
     "profile_no_active_missions": "Por ahora no hay desafíos, pero eso puede cambiar pronto. Mantente cerca.",
     "missions_title": "🎯 *Desafíos disponibles*",
     "missions_no_active": "No hay desafíos por el momento. Aprovecha para tomar aliento.",
-    "mission_not_found": "Ese desafío no existe o ya expiró.",
-    "mission_already_completed": "Ya lo completaste. Buen trabajo.",
-    "mission_completed_success": "✅ ¡Desafío completado! Ganaste `{points_reward}` puntos.",
-    "mission_completed_feedback": "🎉 ¡Misión '{mission_name}' completada! Ganaste `{points_reward}` puntos.",
-    "mission_level_up_bonus": "🚀 Subiste de nivel. Ahora estás en el nivel `{user_level}`. Las cosas se pondrán más interesantes.",
-    "mission_achievement_unlocked": "\n🏆 Logro desbloqueado: *{achievement_name}*",
-    "mission_completion_failed": "❌ No pudimos registrar este desafío. Revisa si ya lo hiciste antes o si aún está activo.",
     "reward_shop_title": "🎁 *Recompensas del Diván*",
     "reward_shop_empty": "Por ahora no hay recompensas disponibles. Pero pronto sí. 😉",
-    "reward_not_found": "Esa recompensa ya no está aquí... o aún no está lista.",
-    "reward_not_registered": "Tu perfil no está activo. Usa /start para comenzar *El Juego del Diván*.",
-    "reward_not_enough_points": "Te faltan `{required_points}` puntos. Ahora tienes `{user_points}`. Pero sigue... estás cerca.",
-    "reward_claim_success": "🎉 ¡Recompensa reclamada!",
-    "reward_claim_failed": "No pudimos procesar tu solicitud.",
-    "reward_already_claimed": "Esta recompensa ya fue reclamada.",
-    # Niveles
-    "level_up_notification": "🎉 ¡Subiste a Nivel {level}: {level_name}! {reward}",
-    "special_level_reward": "✨ Recompensa especial por alcanzar el nivel {level}! {reward}",
-    # Mensajes de ranking (Unificados)
     "ranking_title": "🏆 *Tabla de Posiciones*",
     "ranking_entry": "#{rank}. @{username} - Puntos: `{points}`, Nivel: `{level}`",
     "no_ranking_data": "Aún no hay datos en el ranking. ¡Sé el primero en aparecer!",
-    "back_to_main_menu": "Has regresado al centro del Diván. Elige por dónde seguir explorando.",
-    # Botones
+    "menu_missions_text": "Aquí están los desafíos que puedes emprender. ¡Cada uno te acerca más!",
+    "menu_rewards_text": "¡Es hora de canjear tus puntos! Aquí tienes las recompensas disponibles:",
     "profile_achievements_button_text": "🏅 Mis Logros",
     "profile_active_missions_button_text": "🎯 Mis Desafíos",
     "back_to_profile_button_text": "← Volver a mi rincón",
@@ -59,54 +87,6 @@ BOT_MESSAGES = {
     "prev_page_button_text": "← Anterior",
     "next_page_button_text": "Siguiente →",
     "back_to_main_menu_button_text": "← Volver al inicio",
-    # Detalles
-    "mission_details_text": (
-        "🎯 *Desafío:* {mission_name}\n\n"
-        "📖 *Descripción:* {mission_description}\n"
-        "🎁 *Recompensa:* `{points_reward}` puntos\n"
-        "⏱️ *Frecuencia:* `{mission_type}`"
-    ),
-    "reward_details_text": (
-        "🎁 *Recompensa:* {reward_title}\n\n"
-        "📌 *Descripción:* {reward_description}\n"
-        "🔥 *Requiere:* `{required_points}` puntos"
-    ),
-    "reward_details_not_enough_points_alert": "💔 Te faltan puntos para esta recompensa. Necesitas `{required_points}`, tienes `{user_points}`. Sigue sumando, lo estás haciendo bien.",
-    # Mensajes adicionales que eran mencionados en user_handlers.py
-    "menu_missions_text": "Aquí están los desafíos que puedes emprender. ¡Cada uno te acerca más!",
-    "menu_rewards_text": "¡Es hora de canjear tus puntos! Aquí tienes las recompensas disponibles:",
-    "confirm_purchase_message": "¿Estás segur@ de que quieres canjear {reward_name} por {reward_cost} puntos?",
-    "purchase_cancelled_message": "Compra cancelada. Puedes seguir explorando otras recompensas.",
-    "gain_points_instructions": "Puedes ganar puntos completando misiones y participando en las actividades del canal.",
-    "points_total_notification": "Tienes ahora {total_points} puntos acumulados.",
-    "checkin_success": "✅ Check-in registrado. Ganaste {points} puntos.",
-    "checkin_already_done": "Ya realizaste tu check-in. Vuelve mañana.",
-    "daily_gift_received": "🎁 Recibiste {points} puntos del regalo diario!",
-    "daily_gift_already": "Ya reclamaste el regalo diario. Vuelve mañana.",
-    "daily_gift_disabled": "Regalos diarios deshabilitados.",
-    "minigames_disabled": "Minijuegos deshabilitados.",
-    "dice_points": "Ganaste {points} puntos lanzando el dado.",
-    "trivia_correct": "¡Correcto! +5 puntos",
-    "trivia_wrong": "Respuesta incorrecta.",
-    "unrecognized_command_text": "Comando no reconocido. Aquí está el menú principal:",
-    # Notificaciones de gamificación
-    "challenge_completed": "🎯 ¡Desafío {challenge_type} completado! +{points} puntos",
-    "reaction_registered": "👍 ¡Reacción registrada!",
-    "reaction_registered_points": "👍 ¡Reacción registrada! Ganaste {points} puntos.",
-    "reaction_already": "Ya reaccionaste a este mensaje.",
-    # --- Administración de Recompensas ---
-    "enter_reward_name": "Ingresa el nombre de la recompensa:",
-    "enter_reward_points": "¿Cuántos puntos se requieren?",
-    "enter_reward_description": "Agrega una descripción (opcional):",
-    "select_reward_type": "Selecciona el tipo de recompensa:",
-    "reward_created": "✅ Recompensa creada.",
-    "reward_deleted": "❌ Recompensa eliminada.",
-    "reward_updated": "✅ Recompensa actualizada.",
-    "invalid_number": "Ingresa un número válido.",
-    "user_no_badges": "Aún no has desbloqueado ninguna insignia. ¡Sigue participando!",
-    "level_created": "✅ Nivel creado correctamente.",
-    "level_updated": "✅ Nivel actualizado.",
-    "level_deleted": "❌ Nivel eliminado.",
     "FREE_MENU_TEXT": "✨ *Bienvenid@ a mi espacio gratuito*\n\nElige y descubre un poco de mi mundo...",
     "FREE_GIFT_TEXT": (
         "🎁 *Desbloquear regalo*\n"
@@ -166,7 +146,6 @@ BOT_MESSAGES = {
         "Lo más explícito. Lo más mío. Lo más tuyo.\n\n"
         "*300 MXN (20 USD)*"
     ),
-    "PACK_INTEREST_REPLY": "💌 ¡Gracias! Recibí tu interés. Me pondré en contacto contigo muy pronto. O si no quieres esperar escríbeme directo a mi chat privado en ,,@DianaKinky ",
     "FREE_VIP_EXPLORE_TEXT": (
         "🔐 *Bienvenido al Diván de Diana* 🔐\n\n"
         "¿Te atreves a entrar a mi universo sin censura?\n\n"
@@ -175,10 +154,6 @@ BOT_MESSAGES = {
         "🎁 Descuentos en contenido personalizado\n"
         "👀 Acceso exclusivo a mis historias diarias\n\n"
         "📌 Precio: *$350 MXN / mes*"
-    ),
-    "VIP_INTEREST_REPLY": (
-        "💌 ¡Gracias! Recibí tu interés. Me pondré en contacto contigo muy pronto. "
-        "O si no quieres esperar escríbeme directo a mi chat privado en ,,@DianaKinky "
     ),
     "FREE_CUSTOM_TEXT": (
         "💌 *Quiero contenido personalizado*\n"
@@ -194,24 +169,64 @@ BOT_MESSAGES = {
     ),
 }
 
-# Textos descriptivos para las insignias disponibles en el sistema.
-# El identificador sirve como clave de referencia interna.
-BADGE_TEXTS = {
-    "first_message": {
-        "name": "Primer Mensaje",
-        "description": "Envía tu primer mensaje en el chat",
-    },
-    "conversador": {
-        "name": "Conversador",
-        "description": "Alcanza 100 mensajes enviados",
-    },
-    "invitador": {
-        "name": "Invitador",
-        "description": "Consigue 5 invitaciones exitosas",
-    },
+# ---------------------------------------------------------------------------
+# Mensajes de misiones y minijuegos
+# ---------------------------------------------------------------------------
+GAME_MESSAGES = {
+    "mission_not_found": "Ese desafío no existe o ya expiró.",
+    "mission_already_completed": "Ya lo completaste. Buen trabajo.",
+    "mission_completed_success": "✅ ¡Desafío completado! Ganaste `{points_reward}` puntos.",
+    "mission_completed_feedback": "🎉 ¡Misión '{mission_name}' completada! Ganaste `{points_reward}` puntos.",
+    "mission_level_up_bonus": "🚀 Subiste de nivel. Ahora estás en el nivel `{user_level}`. Las cosas se pondrán más interesantes.",
+    "mission_achievement_unlocked": "\n🏆 Logro desbloqueado: *{achievement_name}*",
+    "mission_completion_failed": "❌ No pudimos registrar este desafío. Revisa si ya lo hiciste antes o si aún está activo.",
+    "reward_not_found": "Esa recompensa ya no está aquí... o aún no está lista.",
+    "reward_not_registered": "Tu perfil no está activo. Usa /start para comenzar *El Juego del Diván*.",
+    "reward_not_enough_points": "Te faltan `{required_points}` puntos. Ahora tienes `{user_points}`. Pero sigue... estás cerca.",
+    "reward_claim_failed": "No pudimos procesar tu solicitud.",
+    "reward_already_claimed": "Esta recompensa ya fue reclamada.",
+    "points_total_notification": "Tienes ahora {total_points} puntos acumulados.",
+    "checkin_success": "✅ Check-in registrado. Ganaste {points} puntos.",
+    "checkin_already_done": "Ya realizaste tu check-in. Vuelve mañana.",
+    "daily_gift_already": "Ya reclamaste el regalo diario. Vuelve mañana.",
+    "daily_gift_disabled": "Regalos diarios deshabilitados.",
+    "minigames_disabled": "Minijuegos deshabilitados.",
+    "dice_points": "Ganaste {points} puntos lanzando el dado.",
+    "trivia_correct": "¡Correcto! +5 puntos",
+    "trivia_wrong": "Respuesta incorrecta.",
+    "challenge_completed": "🎯 ¡Desafío {challenge_type} completado! +{points} puntos",
+    "reaction_registered": "👍 ¡Reacción registrada!",
+    "reaction_registered_points": "👍 ¡Reacción registrada! Ganaste {points} puntos.",
+    "reaction_already": "Ya reaccionaste a este mensaje.",
+    "mission_details_text": (
+        "🎯 *Desafío:* {mission_name}\n\n"
+        "📖 *Descripción:* {mission_description}\n"
+        "🎁 *Recompensa:* `{points_reward}` puntos\n"
+        "⏱️ *Frecuencia:* `{mission_type}`"
+    ),
+    "reward_details_text": (
+        "🎁 *Recompensa:* {reward_title}\n\n"
+        "📌 *Descripción:* {reward_description}\n"
+        "🔥 *Requiere:* `{required_points}` puntos"
+    ),
+    "reward_details_not_enough_points_alert": "💔 Te faltan puntos para esta recompensa. Necesitas `{required_points}`, tienes `{user_points}`. Sigue sumando, lo estás haciendo bien.",
+    "user_no_badges": "Aún no has desbloqueado ninguna insignia. ¡Sigue participando!",
 }
 
-# Plantilla de mensaje para mostrar el nivel del usuario
+# ---------------------------------------------------------------------------
+# Combinación en BOT_MESSAGES para compatibilidad
+# ---------------------------------------------------------------------------
+BOT_MESSAGES = {}
+for _grp in (BUTLER_MESSAGES, KINKY_MESSAGES, MENU_MESSAGES, GAME_MESSAGES):
+    BOT_MESSAGES.update(_grp)
+
+# Textos descriptivos para las insignias disponibles
+BADGE_TEXTS = {
+    "first_message": {"name": "Primer Mensaje", "description": "Envía tu primer mensaje en el chat"},
+    "conversador": {"name": "Conversador", "description": "Alcanza 100 mensajes enviados"},
+    "invitador": {"name": "Invitador", "description": "Consigue 5 invitaciones exitosas"},
+}
+
 NIVEL_TEMPLATE = """
 🎮 Tu nivel actual: {current_level}
 ✨ Puntos totales: {points}


### PR DESCRIPTION
## Summary
- centralize text resources into `messages.py` with Butler/Kinky/Menu/Game categories
- add a playful VIP first welcome message
- send new Kinky welcome before butler instructions on VIP activation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685986dcc48083298f893d8e4ee44241