### PR TITLE
Fix Telegram ID handling

### DIFF
--- a/mybot/handlers/free_channel_admin.py
+++ b/mybot/handlers/free_channel_admin.py
@@ -351,8 +351,8 @@ async def confirm_and_send_post(callback: CallbackQuery, state: FSMContext, sess
 
     if sent_message:
         await callback.bot.edit_message_reply_markup(
-            channel_id,
-            sent_message.message_id,
+            str(channel_id),
+            str(sent_message.message_id),
             reply_markup=get_interactive_post_kb(
                 sent_message.message_id, buttons, None, channel_id
             ),

--- a/mybot/services/free_channel_service.py
+++ b/mybot/services/free_channel_service.py
@@ -177,8 +177,8 @@ class FreeChannelService:
             try:
                 # Aprobar la solicitud en Telegram
                 await self.bot.approve_chat_join_request(
-                    request.chat_id, 
-                    request.user_id
+                    str(request.chat_id),
+                    str(request.user_id)
                 )
                 
                 # Marcar como aprobada en la base de datos
@@ -194,7 +194,7 @@ class FreeChannelService:
                 
                 try:
                     await self.bot.send_message(
-                        request.user_id,
+                        str(request.user_id),
                         welcome_message,
                         parse_mode="Markdown"
                     )
@@ -294,7 +294,7 @@ class FreeChannelService:
                 
                 if media_group:
                     messages = await self.bot.send_media_group(
-                        chat_id=free_channel_id,
+                        chat_id=str(free_channel_id),
                         media=media_group,
                         protect_content=protect_content
                     )
@@ -309,7 +309,7 @@ class FreeChannelService:
                 
                 if media_type == 'photo':
                     sent_message = await self.bot.send_photo(
-                        chat_id=free_channel_id,
+                        chat_id=str(free_channel_id),
                         photo=file_id,
                         caption=text,
                         reply_markup=reply_markup,
@@ -318,7 +318,7 @@ class FreeChannelService:
                     )
                 elif media_type == 'video':
                     sent_message = await self.bot.send_video(
-                        chat_id=free_channel_id,
+                        chat_id=str(free_channel_id),
                         video=file_id,
                         caption=text,
                         reply_markup=reply_markup,
@@ -327,7 +327,7 @@ class FreeChannelService:
                     )
                 elif media_type == 'document':
                     sent_message = await self.bot.send_document(
-                        chat_id=free_channel_id,
+                        chat_id=str(free_channel_id),
                         document=file_id,
                         caption=text,
                         reply_markup=reply_markup,
@@ -336,7 +336,7 @@ class FreeChannelService:
                     )
                 elif media_type == 'audio':
                     sent_message = await self.bot.send_audio(
-                        chat_id=free_channel_id,
+                        chat_id=str(free_channel_id),
                         audio=file_id,
                         caption=text,
                         reply_markup=reply_markup,
@@ -346,7 +346,7 @@ class FreeChannelService:
                 else:
                     # Fallback a mensaje de texto
                     sent_message = await self.bot.send_message(
-                        chat_id=free_channel_id,
+                        chat_id=str(free_channel_id),
                         text=text,
                         reply_markup=reply_markup,
                         protect_content=protect_content,
@@ -355,7 +355,7 @@ class FreeChannelService:
             else:
                 # Mensaje de texto simple
                 sent_message = await self.bot.send_message(
-                    chat_id=free_channel_id,
+                    chat_id=str(free_channel_id),
                     text=text,
                     reply_markup=reply_markup,
                     protect_content=protect_content,
@@ -401,10 +401,10 @@ class FreeChannelService:
                 
                 # Información del canal
                 try:
-                    chat_info = await self.bot.get_chat(free_channel_id)
+                    chat_info = await self.bot.get_chat(str(free_channel_id))
                     stats["channel_title"] = chat_info.title
                     stats["channel_username"] = chat_info.username
-                    stats["channel_member_count"] = await self.bot.get_chat_member_count(free_channel_id)
+                    stats["channel_member_count"] = await self.bot.get_chat_member_count(str(free_channel_id))
                 except Exception as e:
                     logger.warning(f"Could not get channel info: {e}")
                     

--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -52,15 +52,15 @@ class MessageService:
         try:
             buttons = await channel_service.get_reactions(channel_id)
             sent = await self.bot.send_message(
-                channel_id,
+                str(channel_id),
                 text,
                 reply_markup=get_interactive_post_kb(0, buttons, None, channel_id),
 
             )
             counts = await self.get_reaction_counts(sent.message_id)
             await self.bot.edit_message_reply_markup(
-                channel_id,
-                sent.message_id,
+                str(channel_id),
+                str(sent.message_id),
                 reply_markup=get_interactive_post_kb(
 
                     sent.message_id, buttons, counts, channel_id
@@ -71,8 +71,8 @@ class MessageService:
                 vip_reactions = await config.get_vip_reactions()
                 if vip_reactions:
                     await self.bot.set_message_reaction(
-                        channel_id,
-                        sent.message_id,
+                        str(channel_id),
+                        str(sent.message_id),
                         [ReactionTypeEmoji(emoji=r) for r in vip_reactions],
                     )
             return sent
@@ -125,8 +125,8 @@ class MessageService:
         buttons = await config.get_reaction_buttons()
         try:
             await self.bot.edit_message_reply_markup(
-                chat_id,
-                message_id,
+                str(chat_id),
+                str(message_id),
  
                 reply_markup=get_interactive_post_kb(
                     message_id,


### PR DESCRIPTION
## Summary
- ensure IDs are converted to string before calling Telegram API

## Testing
- `pytest -q`
- `python -m compileall -q mybot/services/message_service.py mybot/services/free_channel_service.py mybot/handlers/free_channel_admin.py`

------
https://chatgpt.com/codex/tasks/task_e_6859ae3655ec8329854f2ad128b40234