### PR TITLE
Fix send_interactive_post text value

### DIFF
--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -293,10 +293,11 @@ async def vip_send_channel_post(callback: CallbackQuery, state: FSMContext):
 async def process_vip_channel_post(message: Message, state: FSMContext, session: AsyncSession, bot: Bot):
     if not is_admin(message.from_user.id):
         return
-    await state.update_data(post_text=message.text)
+    text = message.text or ""
+    await state.update_data(post_text=text)
     await send_clean_message(
         message,
-        f"📋 **Previsualización:**\n{message.text}\n\n¿Deseas publicarlo en el canal VIP?",
+        f"📋 **Previsualización:**\n{text}\n\n¿Deseas publicarlo en el canal VIP?",
         reply_markup=get_post_confirmation_keyboard(),
     )
     await state.set_state(AdminContentStates.confirming_channel_post)
@@ -307,7 +308,7 @@ async def confirm_vip_channel_post(callback: CallbackQuery, state: FSMContext, s
     if not is_admin(callback.from_user.id):
         return await callback.answer()
     data = await state.get_data()
-    text = data.get("post_text")
+    text = str(data.get("post_text") or "")
     service = MessageService(session, bot)
     sent = await service.send_interactive_post(text, "vip")
     if sent is None:


### PR DESCRIPTION
## Summary
- ensure `post_text` is stored as string in VIP post flow
- default to empty string before calling `send_interactive_post`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859b77575208329af2617f4079abf58