### PR TITLE
Refactor interactive post flow

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -298,8 +298,8 @@ class Channel(AsyncAttrs, Base):
     __tablename__ = "channels"
     id = Column(BigInteger, primary_key=True)  # Telegram chat ID
     title = Column(String, nullable=True)
-    reactions = Column(String, nullable=True)
-    reaction_points = Column(String, nullable=True)
+    reactions = Column(JSON, nullable=True)
+    reaction_points = Column(JSON, nullable=True)
 
 
 class PendingChannelRequest(AsyncAttrs, Base):

--- a/mybot/handlers/free_channel_admin.py
+++ b/mybot/handlers/free_channel_admin.py
@@ -351,10 +351,13 @@ async def confirm_and_send_post(callback: CallbackQuery, state: FSMContext, sess
 
     if sent_message:
         await callback.bot.edit_message_reply_markup(
-            channel_id,
-            sent_message.message_id,
+            str(channel_id),
+            str(sent_message.message_id),
             reply_markup=get_interactive_post_kb(
-                sent_message.message_id, buttons, None, channel_id
+                sent_message.message_id,
+                buttons,
+                None,
+                channel_id,
             ),
         )
     

--- a/mybot/keyboards/common.py
+++ b/mybot/keyboards/common.py
@@ -13,12 +13,12 @@ def get_back_kb(callback_data: str = "admin_back"):
 
 def get_interactive_post_kb(
     message_id: int,
-    buttons: list[str] | None = None,
+    raw_reactions_data: list[str] | None = None,
     counts: dict[str, int] | None = None,
     channel_id: int | None = None,
 ) -> InlineKeyboardMarkup:
-    """Keyboard with reaction buttons for channel posts."""
-    texts = buttons if buttons else DEFAULT_REACTION_BUTTONS
+    """Build the inline keyboard for interactive posts."""
+    texts = raw_reactions_data if raw_reactions_data else DEFAULT_REACTION_BUTTONS
     builder = InlineKeyboardBuilder()
     for idx, text in enumerate(texts[:10]):
         count = counts.get(f"r{idx}", 0) if counts else 0
@@ -27,6 +27,7 @@ def get_interactive_post_kb(
             cb_data = f"ip_{channel_id}_r{idx}_{message_id}"
         else:
             cb_data = f"ip_r{idx}_{message_id}"
+        cb_data = cb_data[:64]
         builder.button(text=display, callback_data=cb_data)
     builder.adjust(len(texts[:10]))
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- update Channel.reactions fields to JSON
- simplify ChannelService reaction helpers
- adjust interactive post keyboard builder
- enhance interactive post sending logic
- ensure free channel admin uses new API

## Testing
- `python -m py_compile mybot/services/message_service.py mybot/services/channel_service.py mybot/keyboards/common.py mybot/database/models.py mybot/handlers/free_channel_admin.py`

------
https://chatgpt.com/codex/tasks/task_e_6859d728aed88329ac6bef4dee095cec