### PR TITLE
Centralize bot messages

### DIFF
--- a/mybot/handlers/free_user.py
+++ b/mybot/handlers/free_user.py
@@ -7,6 +7,7 @@ from keyboards.subscription_kb import (
     get_free_info_kb,
     get_free_game_kb,
 )
+from utils.messages import BOT_MESSAGES
 from utils.user_roles import is_admin, is_vip
 
 router = Router()
@@ -17,7 +18,7 @@ async def subscription_menu(message: Message):
     if is_admin(message.from_user.id) or await is_vip(message.bot, message.from_user.id):
         return
     await message.answer(
-        "Bienvenido a los kinkys",
+        BOT_MESSAGES["free_welcome"],
         reply_markup=get_subscription_kb(),
     )
 
@@ -27,7 +28,7 @@ async def show_info(callback: CallbackQuery):
     """Display the info section for free users."""
     await callback.answer()
     await callback.message.edit_text(
-        "Información del canal gratuito.",
+        BOT_MESSAGES["free_info_text"],
         reply_markup=get_free_info_kb(),
     )
 
@@ -36,7 +37,7 @@ async def show_info(callback: CallbackQuery):
 async def free_game(callback: CallbackQuery):
     """Placeholder mini game for free users."""
     await callback.message.edit_text(
-        "Mini Juego Kinky (versión gratuita)",
+        BOT_MESSAGES["free_game_title"],
         reply_markup=get_free_game_kb(),
     )
     await callback.answer()

--- a/mybot/handlers/interactive_post.py
+++ b/mybot/handlers/interactive_post.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.message_service import MessageService
 from services.mission_service import MissionService
+from utils.messages import BOT_MESSAGES
 
 router = Router()
 
@@ -31,5 +32,5 @@ async def handle_interactive_post_callback(
         target_message_id=message_id,
         bot=bot,
     )
-    await callback.answer("\u2757 Gracias por reaccionar!")
+    await callback.answer(BOT_MESSAGES["reaction_thanks"])
 

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -9,7 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import User
 from utils.text_utils import sanitize_text
 from utils.menu_manager import menu_manager
-from utils.menu_factory import menu_factory 
+from utils.menu_factory import menu_factory
+from utils.messages import BOT_MESSAGES
 from utils.user_roles import clear_role_cache, is_admin
 from services.tenant_service import TenantService
 import logging
@@ -83,8 +84,8 @@ async def cmd_start(message: Message, session: AsyncSession):
         text, keyboard = await menu_factory.create_menu("admin_main", user_id, session, message.bot)
         
         # Personalizar mensaje de bienvenida para admin al iniciar
-        welcome_prefix = "👑 **¡Bienvenido, Administrador!**\n\n"
-        text = welcome_prefix + text.split('\n\n', 1)[-1] # Mantiene el texto del menú, pero reemplaza el saludo inicial
+        welcome_prefix = BOT_MESSAGES["admin_welcome_prefix"]
+        text = welcome_prefix + text.split('\n\n', 1)[-1]
 
         await menu_manager.show_menu(
             message,
@@ -99,18 +100,11 @@ async def cmd_start(message: Message, session: AsyncSession):
     # Lógica para usuarios no-administradores (VIP, Free)
     try:
         text, keyboard = await menu_factory.create_menu("main", user_id, session, message.bot)
-        
+
         if is_new_user:
-            welcome_prefix = "🌟 **¡Bienvenido!**\n\n"
-            if "suscripción vip" in text.lower() or "experiencia premium" in text.lower():
-                welcome_prefix = "✨ **¡Bienvenido, Miembro VIP!**\n\n"
-            
-            text = welcome_prefix + text
+            await message.answer(BOT_MESSAGES["start_welcome_new_user"])
         else:
-            if "suscripción vip" in text.lower() or "experiencia premium" in text.lower():
-                text = "✨ **Bienvenido de vuelta**\n\n" + text.split('\n\n', 1)[-1]
-            else:
-                text = "🌟 **¡Hola de nuevo!**\n\n" + text.split('\n\n', 1)[-1]
+            await message.answer(BOT_MESSAGES["start_welcome_returning_user"])
         
         await menu_manager.show_menu(
             message, 

--- a/mybot/handlers/user/start_token.py
+++ b/mybot/handlers/user/start_token.py
@@ -9,10 +9,11 @@ from database.models import User
 from utils.text_utils import sanitize_text
 from services.token_service import TokenService
 from services.subscription_service import SubscriptionService
-from utils.menu_utils import send_temporary_reply
+from utils.menu_utils import send_temporary_reply, send_role_menu
 from services.achievement_service import AchievementService
 from services.config_service import ConfigService
 from utils.user_roles import clear_role_cache
+from utils.messages import BOT_MESSAGES
 import logging
 
 logger = logging.getLogger(__name__)
@@ -94,24 +95,22 @@ async def start_with_token(message: Message, command: CommandObject, session: As
             logger.error(f"Failed to create VIP invite link: {e}")
             invite_link = None
 
-    # Send welcome message with invite link
+    # Send special welcome followed by butler instructions
     if invite_link:
-        welcome_msg = (
-            f"🎉 ¡Bienvenido al VIP!\n\n"
-            f"Tu suscripción VIP ha sido activada por {duration} días.\n"
-            f"Expira el: {expires_at.strftime('%d/%m/%Y %H:%M')}\n\n"
-            f"🔗 Únete a nuestro canal VIP exclusivo:\n{invite_link}\n\n"
-            f"⚠️ Este enlace es personal y expira en 24 horas."
+        butler_msg = BOT_MESSAGES["vip_welcome_link"].format(
+            duration=duration,
+            expires_at=expires_at.strftime('%d/%m/%Y %H:%M'),
+            invite_link=invite_link,
         )
     else:
-        welcome_msg = (
-            f"🎉 ¡Suscripción VIP activada!\n\n"
-            f"Duración: {duration} días\n"
-            f"Expira el: {expires_at.strftime('%d/%m/%Y %H:%M')}\n\n"
-            f"Usa /vip_menu para acceder a tus beneficios VIP."
+        butler_msg = BOT_MESSAGES["vip_welcome_no_link"].format(
+            duration=duration,
+            expires_at=expires_at.strftime('%d/%m/%Y %H:%M'),
         )
 
-    await message.answer(welcome_msg)
+    await message.answer(BOT_MESSAGES["vip_special_welcome"])
+    await message.answer(butler_msg)
+    await send_role_menu(message, session)
     logger.info(f"VIP activation completed for user {user_id}")
 
     # Clear role cache again to ensure the new role is detected immediately

--- a/mybot/handlers/vip/menu.py
+++ b/mybot/handlers/vip/menu.py
@@ -15,7 +15,7 @@ from utils.keyboard_utils import (
 )
 from keyboards.vip_main_kb import get_vip_main_kb
 from keyboards.vip_game_kb import get_game_menu_kb
-from utils.messages import BOT_MESSAGES
+from utils.messages import BOT_MESSAGES, MENU_TEXTS
 from utils.message_utils import get_profile_message
 from services.subscription_service import SubscriptionService
 from services.mission_service import MissionService
@@ -39,7 +39,7 @@ async def vip_menu(message: Message, session: AsyncSession):
         return
     await send_menu(
         message,
-        "Bienvenido al Diván de Diana",
+        MENU_TEXTS["vip_main"],
         get_vip_main_kb(),
         session,
         "vip_main",
@@ -60,7 +60,7 @@ async def vip_menu_cb(callback: CallbackQuery, session: AsyncSession):
         return
     await update_menu(
         callback,
-        "Bienvenido al Diván de Diana",
+        MENU_TEXTS["vip_main"],
         get_vip_main_kb(),
         session,
         "vip_main",

--- a/mybot/utils/menu_factory.py
+++ b/mybot/utils/menu_factory.py
@@ -31,6 +31,7 @@ from utils.menu_creators import (
     create_ranking_menu
 )
 from utils.text_utils import sanitize_text # Asegúrate de que esta importación exista y sea correcta
+from utils.messages import MENU_TEXTS
 
 logger = logging.getLogger(__name__)
 
@@ -75,24 +76,18 @@ class MenuFactory:
         """Create the main menu based on user role."""
         if role == "admin":
             return (
-                "🛠️ **Panel de Administración**\n\n"
-                "Bienvenido al centro de control del bot. Desde aquí puedes gestionar "
-                "todos los aspectos del sistema.",
-                get_admin_main_kb()
+                MENU_TEXTS["admin_main"],
+                get_admin_main_kb(),
             )
         elif role == "vip":
             return (
-                "✨ **Bienvenido al Diván de Diana**\n\n"
-                "Tu suscripción VIP te da acceso completo a todas las funciones. "
-                "¡Disfruta de la experiencia premium!",
-                get_vip_main_kb()
+                MENU_TEXTS["vip_main"],
+                get_vip_main_kb(),
             )
-        else: # Covers "free" and any other unrecognized roles
+        else:  # Covers "free" and any other unrecognized roles
             return (
-                "🌟 **Bienvenido a los Kinkys**\n\n"
-                "Explora nuestro contenido gratuito y descubre todo lo que tenemos para ti. "
-                "¿Listo para una experiencia única?",
-                get_subscription_kb()
+                MENU_TEXTS["free_main"],
+                get_subscription_kb(),
             )
     
     async def _create_setup_menu(

--- a/mybot/utils/menu_utils.py
+++ b/mybot/utils/menu_utils.py
@@ -7,15 +7,16 @@ from utils.user_roles import get_user_role
 from keyboards.admin_main_kb import get_admin_main_kb
 from keyboards.vip_main_kb import get_vip_main_kb
 from keyboards.subscription_kb import get_subscription_kb
+from utils.messages import MENU_TEXTS
 
 
 def _menu_details(role: str):
     """Return (text, keyboard, state) for the given role."""
     if role == "admin":
-        return "Panel de Administración", get_admin_main_kb(), "admin_main"
+        return MENU_TEXTS["admin_main"], get_admin_main_kb(), "admin_main"
     if role == "vip":
-        return "Bienvenido al Diván de Diana", get_vip_main_kb(), "vip_main"
-    return "Bienvenido a los Kinkys", get_subscription_kb(), "free_main"
+        return MENU_TEXTS["vip_main"], get_vip_main_kb(), "vip_main"
+    return MENU_TEXTS["free_main"], get_subscription_kb(), "free_main"
 
 # Cache to store the latest menu message for each user
 MENU_CACHE: dict[int, tuple[int, int]] = {}

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -1,145 +1,152 @@
 # utils/messages.py
-BOT_MESSAGES = {
+"""Centralized bot texts organized by speaker and context."""
+
+# Mensajes de la Señorita Kinky
+KINKY_MESSAGES = {
     "start_welcome_new_user": (
-        "🌙 Bienvenid@ a *El Diván de Diana*…\n\n"
-        "Aquí cada gesto, cada decisión y cada paso que das, suma. Con cada interacción, te adentras más en *El Juego del Diván*.\n\n"
-        "¿Estás list@ para descubrir lo que te espera? Elige por dónde empezar, yo me encargo de hacer que lo disfrutes."
+        "🌙 Hola, alma curiosa... Bienvenid@ a *El Diván de Diana*. "
+        "Cada caricia y cada decisión te acercan más a nuestro juego secreto."
     ),
     "start_welcome_returning_user": (
-        "✨ Qué bueno tenerte de regreso.\n\n"
-        "Tu lugar sigue aquí. Tus puntos también... y hay nuevas sorpresas esperándote.\n\n"
-        "¿List@ para continuar *El Juego del Diván*?"
+        "✨ Me alegra tenerte de vuelta. Tus deseos y puntos te estaban esperando."
     ),
-    "vip_members_only": "Esta sección está disponible solo para miembros VIP.",
-    "profile_not_registered": "Parece que aún no has comenzado tu recorrido. Usa /start para dar tu primer paso.",
-    "profile_title": "🛋️ *Tu rincón en El Diván de Diana*",
+    "vip_special_welcome": (
+        "Hola, mi Kinky. Qué emoción que estés aquí, donde todo lo especial sucede. "
+        "Prepárate, porque este será nuestro rincón secreto. Desde ahora te dejo a cargo de mi querido Mayordomo del Diván, él cuidará de ti y te llevará de la mano. "
+        "Pero no te preocupes… seguiré muy, muy cerca."
+    ),
+}
+
+# Mensajes del Mayordomo del Diván
+BUTLER_MESSAGES = {
+    "vip_members_only": "Esta sección está reservada para nuestros distinguidos miembros VIP.",
+    "profile_not_registered": "Aún no he registrado su presencia. Use /start para comenzar su travesía.",
+    "profile_title": "🛋️ *Su rincón en El Diván de Diana*",
     "profile_points": "📌 *Puntos acumulados:* `{user_points}`",
     "profile_level": "🎯 *Nivel actual:* `{user_level}`",
-    "profile_points_to_next_level": "📶 *Para el siguiente nivel:* `{points_needed}` más (Nivel `{next_level}` a partir de `{next_level_threshold}`)",
-    "profile_max_level": "🌟 Has llegado al nivel más alto... y se nota. 😉",
-    "profile_achievements_title": "🏅 *Logros desbloqueados*",
-    "profile_no_achievements": "Aún no hay logros. Pero te tengo fe.",
-    "profile_active_missions_title": "📋 *Tus desafíos activos*",
-    "profile_no_active_missions": "Por ahora no hay desafíos, pero eso puede cambiar pronto. Mantente cerca.",
+    "profile_points_to_next_level": "📶 *Para el siguiente nivel:* `{points_needed}` más (Nivel `{next_level}` desde `{next_level_threshold}`)",
+    "profile_max_level": "🌟 Ha alcanzado el nivel más alto. Mis respetos.",
+    "profile_achievements_title": "🏅 *Logros obtenidos*",
+    "profile_no_achievements": "Aún no cuenta con logros. Confío en que pronto los tendrá.",
+    "profile_active_missions_title": "📋 *Sus desafíos activos*",
+    "profile_no_active_missions": "Por el momento no hay desafíos disponibles. Esté atento.",
+    "back_to_main_menu": "Ha regresado al centro del Diván. Indique cómo desea continuar.",
+    "vip_welcome_link": (
+        "Es un placer darle la bienvenida a nuestro selecto círculo. "
+        "Su suscripción estará activa por {duration} días, hasta {expires_at}.\n\n"
+        "Este es su acceso exclusivo: {invite_link}\n"
+        "Tenga presente que el enlace caduca en 24 horas."
+    ),
+    "vip_welcome_no_link": (
+        "Es un placer darle la bienvenida a nuestro selecto círculo. "
+        "Su suscripción estará activa por {duration} días, hasta {expires_at}.\n\n"
+        "Use /vip_menu para descubrir todas sus ventajas."
+    ),
+}
+
+# Textos de menús y opciones generales
+MENU_TEXTS = {
+    "admin_main": "🛠️ **Panel de Administración**\n\nBienvenido al centro de control del bot. Desde aquí puede gestionar todos los aspectos del sistema.",
+    "vip_main": "✨ **Bienvenido al Diván de Diana**\n\nSu suscripción VIP le otorga acceso completo a todas las funciones. Disfrute de la experiencia premium.",
+    "free_main": "🌟 **Bienvenido a los Kinkys**\n\nExplore nuestro contenido gratuito y descubra todo lo que tenemos para usted. ¿Listo para una experiencia única?",
+    "menu_missions_text": "Aquí se muestran los desafíos disponibles. Cada uno lo acerca más a nuevas recompensas.",
+    "menu_rewards_text": "Es momento de canjear sus puntos. Estas son las recompensas disponibles:",
+    "unrecognized_command_text": "Comando no reconocido. Este es el menú principal:",
+    "free_welcome": "Bienvenido a los kinkys",
+    "free_info_text": "Información del canal gratuito.",
+    "free_game_title": "Mini Juego Kinky (versión gratuita)",
+    "admin_welcome_prefix": "👑 **¡Bienvenido, Administrador!**\n\n",
+}
+
+# Mensajes de misiones y minijuegos
+MISSION_MESSAGES = {
     "missions_title": "🎯 *Desafíos disponibles*",
-    "missions_no_active": "No hay desafíos por el momento. Aprovecha para tomar aliento.",
-    "mission_not_found": "Ese desafío no existe o ya expiró.",
-    "mission_already_completed": "Ya lo completaste. Buen trabajo.",
-    "mission_completed_success": "✅ ¡Desafío completado! Ganaste `{points_reward}` puntos.",
-    "mission_completed_feedback": "🎉 ¡Misión '{mission_name}' completada! Ganaste `{points_reward}` puntos.",
-    "mission_level_up_bonus": "🚀 Subiste de nivel. Ahora estás en el nivel `{user_level}`. Las cosas se pondrán más interesantes.",
+    "missions_no_active": "No hay desafíos por ahora. Aproveche para descansar.",
+    "mission_not_found": "Ese desafío no existe o ha expirado.",
+    "mission_already_completed": "Ese desafío ya fue completado. Excelente trabajo.",
+    "mission_completed_success": "✅ Desafío completado. Ha ganado `{points_reward}` puntos.",
+    "mission_completed_feedback": "🎉 Misión '{mission_name}' completada. Ha ganado `{points_reward}` puntos.",
+    "mission_level_up_bonus": "🚀 ¡Ha subido al nivel `{user_level}`! Todo se vuelve más interesante.",
     "mission_achievement_unlocked": "\n🏆 Logro desbloqueado: *{achievement_name}*",
-    "mission_completion_failed": "❌ No pudimos registrar este desafío. Revisa si ya lo hiciste antes o si aún está activo.",
+    "mission_completion_failed": "❌ No fue posible registrar este desafío. Verifique si ya lo completó o si sigue activo.",
     "reward_shop_title": "🎁 *Recompensas del Diván*",
-    "reward_shop_empty": "Por ahora no hay recompensas disponibles. Pero pronto sí. 😉",
-    "reward_not_found": "Esa recompensa ya no está aquí... o aún no está lista.",
-    "reward_not_registered": "Tu perfil no está activo. Usa /start para comenzar *El Juego del Diván*.",
-    "reward_not_enough_points": "Te faltan `{required_points}` puntos. Ahora tienes `{user_points}`. Pero sigue... estás cerca.",
-    "reward_claim_success": "🎉 ¡Recompensa reclamada!",
-    "reward_claim_failed": "No pudimos procesar tu solicitud.",
-    "reward_already_claimed": "Esta recompensa ya fue reclamada.",
-    # Niveles
-    "level_up_notification": "🎉 ¡Subiste a Nivel {level}: {level_name}! {reward}",
+    "reward_shop_empty": "Por ahora no hay recompensas disponibles, pero pronto las habrá.",
+    "reward_not_found": "Esa recompensa ya no se encuentra disponible.",
+    "reward_not_registered": "Su perfil aún no está activo. Use /start para comenzar El Juego del Diván.",
+    "reward_not_enough_points": "Necesita `{required_points}` puntos y posee `{user_points}`. Continúe acumulando para obtenerla.",
+    "reward_claim_success": "🎉 Recompensa reclamada con éxito.",
+    "reward_claim_failed": "No fue posible procesar su solicitud.",
+    "reward_already_claimed": "Esta recompensa ya ha sido reclamada.",
+    "level_up_notification": "🎉 ¡Subió a Nivel {level}: {level_name}! {reward}",
     "special_level_reward": "✨ Recompensa especial por alcanzar el nivel {level}! {reward}",
-    # Mensajes de ranking (Unificados)
     "ranking_title": "🏆 *Tabla de Posiciones*",
     "ranking_entry": "#{rank}. @{username} - Puntos: `{points}`, Nivel: `{level}`",
-    "no_ranking_data": "Aún no hay datos en el ranking. ¡Sé el primero en aparecer!",
+    "no_ranking_data": "Aún no hay datos en el ranking. Sea el primero en aparecer.",
     "weekly_ranking_title": "🏆 Ranking Semanal de Reacciones",
     "weekly_ranking_entry": "#{rank}. {username} - Reacciones: {count}",
     "weekly_no_data": "Aún no hay reacciones registradas esta semana.",
-    "back_to_main_menu": "Has regresado al centro del Diván. Elige por dónde seguir explorando.",
-    # Botones
-    "profile_achievements_button_text": "🏅 Mis Logros",
-    "profile_active_missions_button_text": "🎯 Mis Desafíos",
-    "back_to_profile_button_text": "← Volver a mi rincón",
-    "view_all_missions_button_text": "Ver todos los desafíos",
-    "back_to_missions_button_text": "← Volver a desafíos",
-    "complete_mission_button_text": "✅ Completado",
-    "confirm_purchase_button_text": "Canjear por `{cost}` puntos",
-    "cancel_purchase_button_text": "❌ Cancelar",
-    "back_to_rewards_button_text": "← Volver a recompensas",
-    "prev_page_button_text": "← Anterior",
-    "next_page_button_text": "Siguiente →",
-    "back_to_main_menu_button_text": "← Volver al inicio",
-    # Detalles
-    "mission_details_text": (
-        "🎯 *Desafío:* {mission_name}\n\n"
-        "📖 *Descripción:* {mission_description}\n"
-        "🎁 *Recompensa:* `{points_reward}` puntos\n"
-        "⏱️ *Frecuencia:* `{mission_type}`"
-    ),
-    "reward_details_text": (
-        "🎁 *Recompensa:* {reward_title}\n\n"
-        "📌 *Descripción:* {reward_description}\n"
-        "🔥 *Requiere:* `{required_points}` puntos"
-    ),
-    "reward_details_not_enough_points_alert": "💔 Te faltan puntos para esta recompensa. Necesitas `{required_points}`, tienes `{user_points}`. Sigue sumando, lo estás haciendo bien.",
-    # Mensajes adicionales que eran mencionados en user_handlers.py
-    "menu_missions_text": "Aquí están los desafíos que puedes emprender. ¡Cada uno te acerca más!",
-    "menu_rewards_text": "¡Es hora de canjear tus puntos! Aquí tienes las recompensas disponibles:",
-    "confirm_purchase_message": "¿Estás segur@ de que quieres canjear {reward_name} por {reward_cost} puntos?",
-    "purchase_cancelled_message": "Compra cancelada. Puedes seguir explorando otras recompensas.",
-    "gain_points_instructions": "Puedes ganar puntos completando misiones y participando en las actividades del canal.",
-    "points_total_notification": "Tienes ahora {total_points} puntos acumulados.",
-    "checkin_success": "✅ Check-in registrado. Ganaste {points} puntos.",
-    "checkin_already_done": "Ya realizaste tu check-in. Vuelve mañana.",
-    "daily_gift_received": "🎁 Recibiste {points} puntos del regalo diario!",
-    "daily_gift_already": "Ya reclamaste el regalo diario. Vuelve mañana.",
+    "confirm_purchase_message": "¿Confirma que desea canjear {reward_name} por {reward_cost} puntos?",
+    "purchase_cancelled_message": "Compra cancelada. Puede seguir explorando otras recompensas.",
+    "gain_points_instructions": "Puede ganar puntos completando misiones y participando en las actividades del canal.",
+    "points_total_notification": "Ahora cuenta con {total_points} puntos acumulados.",
+    "checkin_success": "✅ Check-in registrado. Ha ganado {points} puntos.",
+    "checkin_already_done": "Ya registró su check-in. Vuelva mañana.",
+    "daily_gift_received": "🎁 Ha recibido {points} puntos del regalo diario!",
+    "daily_gift_already": "Ya reclamó el regalo diario. Vuelva mañana.",
     "daily_gift_disabled": "Regalos diarios deshabilitados.",
     "minigames_disabled": "Minijuegos deshabilitados.",
-    "dice_points": "Ganaste {points} puntos lanzando el dado.",
-    "roulette_no_free": "Ya usaste tu tiro gratis. Compra giros extra.",
-    "roulette_result": "Resultado {score}, ganaste {points} puntos.",
+    "dice_points": "Ha ganado {points} puntos lanzando el dado.",
+    "roulette_no_free": "Ya utilizó su tiro gratis. Puede comprar giros extra.",
+    "roulette_result": "Resultado {score}, ha ganado {points} puntos.",
     "roulette_bought": "Tiro extra comprado.",
-    "roulette_buy_fail": "No tienes puntos suficientes.",
+    "roulette_buy_fail": "No posee puntos suficientes.",
     "trivia_correct": "¡Correcto! +5 puntos",
     "trivia_wrong": "Respuesta incorrecta.",
-    "reto_start": "Reacciona a {target} publicaciones en {seconds} segundos.",
+    "reto_start": "Reaccione a {target} publicaciones en {seconds} segundos.",
     "reto_success": "¡Reto completado!",
-    "reto_failed": "No completaste el reto y perdiste puntos.",
-    "unrecognized_command_text": "Comando no reconocido. Aquí está el menú principal:",
-    # Notificaciones de gamificación
-    "challenge_completed": "🎯 ¡Desafío {challenge_type} completado! +{points} puntos",
-    "reaction_registered": "👍 ¡Reacción registrada!",
-    # --- Administración de Recompensas ---
-    "enter_reward_name": "Ingresa el nombre de la recompensa:",
+    "reto_failed": "No completó el reto y perdió puntos.",
+    "challenge_completed": "🎯 Desafío {challenge_type} completado. +{points} puntos",
+    "reaction_registered": "👍 Reacción registrada.",
+    "reaction_thanks": "¡Gracias por reaccionar!",
+    "enter_reward_name": "Ingrese el nombre de la recompensa:",
     "enter_reward_points": "¿Cuántos puntos se requieren?",
-    "enter_reward_description": "Agrega una descripción (opcional):",
-    "select_reward_type": "Selecciona el tipo de recompensa:",
+    "enter_reward_description": "Agregue una descripción (opcional):",
+    "select_reward_type": "Seleccione el tipo de recompensa:",
     "reward_created": "✅ Recompensa creada.",
     "reward_deleted": "❌ Recompensa eliminada.",
     "reward_updated": "✅ Recompensa actualizada.",
-    "invalid_number": "Ingresa un número válido.",
-    "user_no_badges": "Aún no has desbloqueado ninguna insignia. ¡Sigue participando!",
+    "invalid_number": "Ingrese un número válido.",
+    "user_no_badges": "Aún no ha desbloqueado ninguna insignia. Continúe participando.",
     "level_created": "✅ Nivel creado correctamente.",
     "level_updated": "✅ Nivel actualizado.",
     "level_deleted": "❌ Nivel eliminado.",
     "auto_mission_reaction_name": "Reaccionar a la publicación",
-    "auto_mission_reaction_desc": "Pulsa cualquier reacción para completar la misión.",
+    "auto_mission_reaction_desc": "Pulse cualquier reacción para completar la misión.",
 }
 
-# Textos descriptivos para las insignias disponibles en el sistema.
-# El identificador sirve como clave de referencia interna.
+# Unión de todos los mensajes para compatibilidad con el código existente
+BOT_MESSAGES = {**KINKY_MESSAGES, **BUTLER_MESSAGES, **MENU_TEXTS, **MISSION_MESSAGES}
+
+# Textos descriptivos de insignias
 BADGE_TEXTS = {
     "first_message": {
         "name": "Primer Mensaje",
-        "description": "Envía tu primer mensaje en el chat",
+        "description": "Envíe su primer mensaje en el chat",
     },
     "conversador": {
         "name": "Conversador",
-        "description": "Alcanza 100 mensajes enviados",
+        "description": "Alcance 100 mensajes enviados",
     },
     "invitador": {
         "name": "Invitador",
-        "description": "Consigue 5 invitaciones exitosas",
+        "description": "Consiga 5 invitaciones exitosas",
     },
 }
 
 # Plantilla de mensaje para mostrar el nivel del usuario
 NIVEL_TEMPLATE = """
-🎮 Tu nivel actual: {current_level}
+🎮 Su nivel actual: {current_level}
 ✨ Puntos totales: {points}
 📊 Progreso hacia el siguiente nivel: {percentage:.1%}
-🎯 Te faltan {points_needed} puntos para alcanzar el nivel {next_level}.
+🎯 Le faltan {points_needed} puntos para alcanzar el nivel {next_level}.
 """


### PR DESCRIPTION
## Summary
- centralize texts in `messages.py`
- add categories for Kinky, Butler, menu, missions
- integrate new VIP welcome flow using Kinky message and Butler message
- update start handler and others to use centralized messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859e8d11cdc8329b7c6b1b690b50f27