### PR TITLE
Anonymize rankings except admins and viewer

### DIFF
--- a/mybot/handlers/vip/gamification.py
+++ b/mybot/handlers/vip/gamification.py
@@ -416,7 +416,7 @@ async def show_weekly_ranking(message: Message, session: AsyncSession, bot: Bot)
     msg_service = MessageService(session, bot)
     ranking = await msg_service.get_weekly_reaction_ranking()
     from utils.message_utils import get_weekly_reaction_ranking_message
-    text = await get_weekly_reaction_ranking_message(ranking, session)
+    text = await get_weekly_reaction_ranking_message(ranking, session, user_id)
     await message.answer(text)
     
     try:

--- a/mybot/utils/menu_creators.py
+++ b/mybot/utils/menu_creators.py
@@ -92,5 +92,5 @@ async def create_ranking_menu(user_id: int, session: AsyncSession) -> Tuple[str,
     point_service = PointService(session)
     top_users = await point_service.get_top_users(limit=10)
     
-    ranking_text = await get_ranking_message(top_users)
+    ranking_text = await get_ranking_message(top_users, user_id)
     return ranking_text, get_ranking_keyboard()

--- a/mybot/utils/message_utils.py
+++ b/mybot/utils/message_utils.py
@@ -101,7 +101,7 @@ async def get_reward_details_message(reward: Reward, user_points: int) -> str:
     )
 
 
-async def get_ranking_message(users_ranking: list[User]) -> str:
+async def get_ranking_message(users_ranking: list[User], viewer_user_id: int) -> str:
     """
     Generates a formatted message for the user ranking with anonymized usernames.
     """
@@ -111,9 +111,7 @@ async def get_ranking_message(users_ranking: list[User]) -> str:
         return ranking_text + BOT_MESSAGES["no_ranking_data"]
 
     for i, user in enumerate(users_ranking):
-        # Anonymize usernames for all users except when viewing own ranking
-        # Since we don't have the viewer's ID here, we'll anonymize all for privacy
-        display_name = anonymize_username(user, -1)  # -1 means anonymize for everyone
+        display_name = anonymize_username(user, viewer_user_id)
         
         ranking_text += (
             BOT_MESSAGES["ranking_entry"].format(
@@ -128,13 +126,13 @@ async def get_ranking_message(users_ranking: list[User]) -> str:
     return ranking_text
 
 
-async def get_weekly_reaction_ranking_message(ranking: list[tuple[int, int]], session: AsyncSession) -> str:
+async def get_weekly_reaction_ranking_message(ranking: list[tuple[int, int]], session: AsyncSession, viewer_user_id: int) -> str:
     text = BOT_MESSAGES["weekly_ranking_title"] + "\n\n"
     if not ranking:
         return text + BOT_MESSAGES["no_ranking_data"]
     for idx, (user_id, count) in enumerate(ranking):
         user = await session.get(User, user_id)
-        display_name = anonymize_username(user, -1)
+        display_name = anonymize_username(user, viewer_user_id)
         text += BOT_MESSAGES["weekly_ranking_entry"].format(rank=idx + 1, username=display_name, count=count) + "\n"
     return text
 

--- a/mybot/utils/text_utils.py
+++ b/mybot/utils/text_utils.py
@@ -1,4 +1,5 @@
 import re
+from .config import ADMIN_IDS
 
 
 def sanitize_text(value: str | None) -> str | None:
@@ -8,22 +9,26 @@ def sanitize_text(value: str | None) -> str | None:
     return value.encode("utf-8", "ignore").decode("utf-8", "ignore")
 
 
-def anonymize_username(user, current_user_id: int) -> str:
+def anonymize_username(user, current_user_id: int, admin_ids: list[int] | None = None) -> str:
     """
-    Anonymize username for display, showing full info only to the user themselves.
+    Anonymize username for display, showing full info only to the viewer and admins.
     
     Args:
         user: User object with id, username, first_name, last_name
         current_user_id: ID of the user viewing the information
+        admin_ids: Optional list of admin IDs to show without anonymization
         
     Returns:
         str: Full name/username for own user, anonymized for others
     """
     if not user:
         return "Usuario desconocido"
+
+    if admin_ids is None:
+        admin_ids = ADMIN_IDS
     
-    # Show full info to the user themselves
-    if user.id == current_user_id:
+    # Show full info to the user themselves or if user is admin
+    if user.id == current_user_id or user.id in admin_ids:
         if user.username:
             return f"@{user.username}"
         elif user.first_name:


### PR DESCRIPTION
## Summary
- expose admin IDs to text utilities
- show admins and the viewer's full name in any anonymized display
- pass viewer ID when generating ranking messages

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859f93a34e88329a12cff42fbcc6df2