### PR TITLE
Add reactions fields to Channel model

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -300,6 +300,10 @@ class Channel(AsyncAttrs, Base):
     __tablename__ = "channels"
     id = Column(BigInteger, primary_key=True)  # Telegram chat ID
     title = Column(String, nullable=True)
+    # --- NUEVAS COLUMNAS ---
+    reactions = Column(JSON, default=list)  # Guarda una lista de strings (ej. ["👍", "❤️", "😂"])
+    reaction_points = Column(JSON, default=dict)  # Guarda un diccionario {emoji: puntos} (ej. {"👍": 0.5, "❤️": 1.0})
+    # --- FIN NUEVAS COLUMNAS ---
 
 
 class PendingChannelRequest(AsyncAttrs, Base):


### PR DESCRIPTION
## Summary
- add `reactions` and `reaction_points` columns to the `Channel` model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a89f2b9e48329b14ba32833030442