### PR TITLE
Add per-channel reaction configuration

### DIFF
--- a/mybot/utils/config.py
+++ b/mybot/utils/config.py
@@ -38,7 +38,7 @@ VIP_SCHEDULER_INTERVAL = int(os.environ.get("VIP_SCHEDULER_INTERVAL", "3600"))
 
 # Default reaction button texts used on channel posts when no custom values
 # are configured via the admin settings menu.
-DEFAULT_REACTION_BUTTONS = ["👍 Me gusta", "🔁 Compartir", "🔥 Sexy"]
+DEFAULT_REACTION_BUTTONS = ["👍", "❤️", "😂", "🔥", "💯"]
 
 class Config:
     BOT_TOKEN = BOT_TOKEN


### PR DESCRIPTION
## Summary
- log ChannelService events
- allow configuring reactions and points for each channel
- define default reaction list in config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685acf3bb974832996be656a339c34dc