### PR TITLE
Fix interactive post flow

### DIFF
--- a/mybot/handlers/interactive_post.py
+++ b/mybot/handlers/interactive_post.py
@@ -3,6 +3,8 @@ from aiogram.types import CallbackQuery
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.message_service import MessageService
+from services.channel_service import ChannelService
+from utils.messages import BOT_MESSAGES
 
 router = Router()
 
@@ -12,42 +14,48 @@ async def handle_interactive_post_callback(
     callback: CallbackQuery, session: AsyncSession, bot: Bot
 ):
     parts = callback.data.split("_")
-    if len(parts) < 3:
+    if len(parts) < 4:
         return await callback.answer()
-    reaction_type = parts[1]  # e.g. 'r0'
+
+    try:
+        channel_id = int(parts[1])
+    except ValueError:
+        channel_id = parts[1]
+
     try:
         message_id = int(parts[2])
     except ValueError:
         return await callback.answer()
 
+    reaction_type = parts[3]
+
     service = MessageService(session, bot)
+    channel_service = ChannelService(session)
 
-    reaction = await service.register_reaction(
-        callback.from_user.id, message_id, reaction_type
+    reaction_result = await service.register_reaction(
+        callback.from_user.id,
+        message_id,
+        reaction_type,
     )
-    if reaction is None:
-        from utils.messages import BOT_MESSAGES
 
-        await callback.answer(BOT_MESSAGES["reaction_already"])
-
+    if reaction_result is None:
+        await callback.answer(
+            BOT_MESSAGES.get("reaction_already", "Ya has reaccionado a este post."),
+            show_alert=True,
+        )
         return
-    from services.point_service import PointService
-    from services.config_service import ConfigService
-    from utils.messages import BOT_MESSAGES
 
-    config = ConfigService(session)
-    points_list = await config.get_reaction_points()
-    idx = 0
-    try:
-        idx = int(reaction_type[1:])
-    except (ValueError, IndexError):
-        pass
-    points = points_list[idx] if idx < len(points_list) else 0.0
+    from services.point_service import PointService
+
+    points_dict = await channel_service.get_reaction_points(channel_id)
+    points = float(points_dict.get(reaction_type, 0.0))
+
     await PointService(session).add_points(callback.from_user.id, points, bot=bot)
     from services.mission_service import MissionService
     mission_service = MissionService(session)
     await mission_service.update_progress(callback.from_user.id, "reaction", bot=bot)
-    await service.update_reaction_markup(callback.message.chat.id, message_id)
+    chat_id_str = str(callback.message.chat.id)
+    await service.update_reaction_markup(chat_id_str, message_id)
     await callback.answer(BOT_MESSAGES["reaction_registered_points"].format(points=points))
     await bot.send_message(
         callback.from_user.id,

--- a/mybot/keyboards/common.py
+++ b/mybot/keyboards/common.py
@@ -13,15 +13,32 @@ def get_back_kb(callback_data: str = "admin_back"):
 
 def get_interactive_post_kb(
     message_id: int,
-    buttons: list[str] | None = None,
-    counts: dict[str, int] | None = None,
+    raw_reactions: list[str],
+    channel_id: int,
+    reaction_counts: dict[str, int] | None = None,
 ) -> InlineKeyboardMarkup:
-    """Keyboard with reaction buttons for channel posts."""
-    texts = buttons if buttons else DEFAULT_REACTION_BUTTONS
+    """
+    Keyboard with reaction buttons for channel posts.
+    Always returns a valid InlineKeyboardMarkup.
+    """
     builder = InlineKeyboardBuilder()
-    for idx, text in enumerate(texts[:10]):
-        count = counts.get(f"r{idx}", 0) if counts else 0
-        display = f"{text} {count}"
-        builder.button(text=display, callback_data=f"ip_r{idx}_{message_id}")
-    builder.adjust(len(texts[:10]))
+
+    if reaction_counts is None:
+        reaction_counts = {}
+
+    reactions_to_use = raw_reactions if raw_reactions else DEFAULT_REACTION_BUTTONS
+
+    for emoji in reactions_to_use[:10]:
+        count = reaction_counts.get(emoji, 0)
+        display = f"{emoji} {count}"
+        callback_data = f"ip_{channel_id}_{message_id}_{emoji}"
+        builder.button(text=display, callback_data=callback_data)
+
+    if builder.buttons:
+        num_buttons = len(builder.buttons)
+        if num_buttons <= 4:
+            builder.adjust(num_buttons)
+        else:
+            builder.adjust(4)
+
     return builder.as_markup()

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -166,6 +166,8 @@ MISSION_MESSAGES = {
     "dice_points": "Ganó {points} puntos lanzando el dado.",
     "trivia_correct": "¡Correcto! +5 puntos",
     "trivia_wrong": "Respuesta incorrecta.",
+    "reaction_registered_points": "✅ Reacci\u00f3n registrada. Ganaste {points} puntos.",
+    "reaction_already": "Ya has reaccionado a este post.",
     "weekly_ranking_title": "🏅 Ranking Semanal de Reacciones",
     "weekly_ranking_entry": "#{rank}. @{username} - {count} reacciones",
     "challenge_started": "Reto iniciado! Reacciona a {count} publicaciones para ganar puntos.",


### PR DESCRIPTION
## Summary
- add detailed logging and ChannelService usage to `MessageService`
- update reaction keyboard to include channel ID
- fix interactive post callback logic
- add messages for interactive post reactions

## Testing
- `ruff check mybot/handlers/interactive_post.py mybot/keyboards/common.py mybot/services/message_service.py mybot/utils/messages.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae9674dec8329afac03e52ef782ef