### PR TITLE
Remove VIP reactions option

### DIFF
--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -4,7 +4,6 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 def get_admin_config_kb():
     builder = InlineKeyboardBuilder()
     builder.button(text="📝 Configurar Reacciones", callback_data="config_reaction_buttons")
-    builder.button(text="🤖 Reacciones VIP", callback_data="config_vip_reactions")
     builder.button(text="➕ Agregar canales", callback_data="config_add_channels")
     builder.button(text="⏱️ Schedulers", callback_data="config_scheduler")
     builder.button(text="🔙 Volver", callback_data="admin_back")

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -65,7 +65,6 @@ class AdminConfigStates(StatesGroup):
 
     waiting_for_reaction_buttons = State()
     waiting_for_reaction_points = State()
-    waiting_for_vip_reactions = State()
     waiting_for_channel_choice = State()
     waiting_for_channel_interval = State()
     waiting_for_vip_interval = State()


### PR DESCRIPTION
## Summary
- drop VIP reactions from admin config menu
- clean up states and handlers related to VIP reactions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685af0bab5a4832983a464366ad0098a