### PR TITLE
Add VIP channel reactions menu

### DIFF
--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -12,6 +12,7 @@ from keyboards.admin_vip_config_kb import (
     get_tariff_select_kb,
     get_vip_messages_kb,
 )
+from keyboards.admin_vip_channel_kb import get_admin_vip_channel_kb
 from utils.keyboard_utils import (
     get_back_keyboard,
     get_main_menu_keyboard,
@@ -60,8 +61,8 @@ async def vip_menu(callback: CallbackQuery, session: AsyncSession):
         return await callback.answer()
     await update_menu(
         callback,
-        "🔐 Administración Canal VIP",
-        get_admin_vip_kb(),
+        "📢 Canal VIP - Opciones",
+        get_admin_vip_channel_kb(),
         session,
         "admin_vip",
     )

--- a/mybot/keyboards/admin_vip_channel_kb.py
+++ b/mybot/keyboards/admin_vip_channel_kb.py
@@ -1,0 +1,11 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+
+
+def get_admin_vip_channel_kb() -> InlineKeyboardMarkup:
+    """Returns the keyboard for the VIP Channel admin menu."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📝 Configurar Reacciones VIP", callback_data="vip_config_reactions")
+    builder.button(text="🔙 Volver al Menú Admin", callback_data="admin_main")
+    builder.adjust(1)
+    return builder.as_markup()


### PR DESCRIPTION
## Summary
- create keyboard for VIP channel admin
- show VIP channel admin options when pressing Canal VIP

## Testing
- `python -m compileall -q mybot`

------
https://chatgpt.com/codex/tasks/task_e_685afe0fd3a08329abf362342660c7c6