### PR TITLE
Add VIP channel menu for reaction setup

### DIFF
--- a/mybot/handlers/admin/vip_menu.py
+++ b/mybot/handlers/admin/vip_menu.py
@@ -12,6 +12,7 @@ from keyboards.admin_vip_config_kb import (
     get_tariff_select_kb,
     get_vip_messages_kb,
 )
+from keyboards.admin_vip_channel_kb import get_admin_vip_channel_kb
 from utils.keyboard_utils import (
     get_back_keyboard,
     get_main_menu_keyboard,
@@ -61,7 +62,7 @@ async def vip_menu(callback: CallbackQuery, session: AsyncSession):
     await update_menu(
         callback,
         "🔐 Administración Canal VIP",
-        get_admin_vip_kb(),
+        get_admin_vip_channel_kb(),
         session,
         "admin_vip",
     )

--- a/mybot/keyboards/admin_config_kb.py
+++ b/mybot/keyboards/admin_config_kb.py
@@ -3,7 +3,6 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 def get_admin_config_kb():
     builder = InlineKeyboardBuilder()
-    builder.button(text="📝 Configurar Reacciones", callback_data="config_reaction_buttons")
     builder.button(text="➕ Agregar canales", callback_data="config_add_channels")
     builder.button(text="⏱️ Schedulers", callback_data="config_scheduler")
     builder.button(text="🔙 Volver", callback_data="admin_back")

--- a/mybot/keyboards/admin_vip_channel_kb.py
+++ b/mybot/keyboards/admin_vip_channel_kb.py
@@ -1,0 +1,12 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+
+
+def get_admin_vip_channel_kb() -> InlineKeyboardMarkup:
+    """Returns the keyboard for the VIP Channel admin menu."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="📝 Configurar Reacciones VIP", callback_data="vip_config_reactions")
+    # Puedes añadir otras opciones específicas del canal VIP aquí en el futuro si las tienes
+    builder.button(text="🔙 Volver al Menú Admin", callback_data="admin_main")
+    builder.adjust(1)
+    return builder.as_markup()


### PR DESCRIPTION
## Summary
- drop global reaction config button from admin config menu
- create a keyboard for VIP channel administration
- show this keyboard when selecting the VIP option in admin menu

## Testing
- `pytest -q`
- `python -m py_compile mybot/keyboards/admin_vip_channel_kb.py mybot/keyboards/admin_config_kb.py mybot/handlers/admin/vip_menu.py`


------
https://chatgpt.com/codex/tasks/task_e_685b0636235c83299944a344689939fc