### PR TITLE
Fix button count in interactive keyboard

### DIFF
--- a/mybot/keyboards/common.py
+++ b/mybot/keyboards/common.py
@@ -34,8 +34,12 @@ def get_interactive_post_kb(
         callback_data = f"ip_{channel_id}_{message_id}_{emoji}"
         builder.button(text=display, callback_data=callback_data)
 
-    if builder.buttons:
-        num_buttons = len(builder.buttons)
+    keyboard_data = builder.export()
+    if keyboard_data:
+        # ``buttons`` is a generator, therefore ``len`` cannot be applied
+        # directly. ``export`` returns a list of rows with the created buttons,
+        # which allows us to count them reliably.
+        num_buttons = sum(len(row) for row in keyboard_data)
         if num_buttons <= 4:
             builder.adjust(num_buttons)
         else:


### PR DESCRIPTION
## Summary
- fix len() issue when counting buttons in interactive post kb

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b296fc8ec8329aba7684fc2283491