### PR TITLE
Fix mission button text key error

### DIFF
--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -171,6 +171,7 @@ MISSION_MESSAGES = {
     "weekly_ranking_title": "🏅 Ranking Semanal de Reacciones",
     "weekly_ranking_entry": "#{rank}. @{username} - {count} reacciones",
     "challenge_started": "Reto iniciado! Reacciona a {count} publicaciones para ganar puntos.",
+    "view_all_missions_button_text": "📋 Ver Todas las Misiones",
 }
 
 # Aggregate all messages for backward compatibility


### PR DESCRIPTION
## Summary
- add missing `view_all_missions_button_text` key to mission messages

## Testing
- `python -m py_compile mybot/utils/messages.py`

------
https://chatgpt.com/codex/tasks/task_e_685b2e0e64808329bdee109c955d7c70