### PR TITLE
Fix mission progress null values

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -135,7 +135,7 @@ class UserMissionProgress(AsyncAttrs, Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(BigInteger, ForeignKey("users.id"))
     mission_id = Column(String, ForeignKey("missions.id"))
-    progress_value = Column(Integer, default=0)
+    progress_value = Column(Integer, default=0, nullable=False)
     completed = Column(Boolean, default=False)
     completed_at = Column(DateTime, nullable=True)
 

--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -224,6 +224,8 @@ class MissionService:
                 progress = current_value
                 record.progress_value = progress
             else:
+                if record.progress_value is None:
+                    record.progress_value = 0
                 record.progress_value += increment
                 progress = record.progress_value
             if progress >= mission.target_value:


### PR DESCRIPTION
## Summary
- ensure mission progress defaults to zero if unset in database
- guard against `None` progress_value before incrementing missions

## Testing
- `python -m py_compile mybot/services/mission_service.py mybot/database/models.py`


------
https://chatgpt.com/codex/tasks/task_e_685b33a1df7083298fa22728c751087c