### PR TITLE
Fix reaction counts arg order

### DIFF
--- a/mybot/handlers/free_channel_admin.py
+++ b/mybot/handlers/free_channel_admin.py
@@ -339,10 +339,16 @@ async def confirm_and_send_post(callback: CallbackQuery, state: FSMContext, sess
     
     config = ConfigService(session)
     buttons = await config.get_reaction_buttons()
+    channel_id = await config.get_free_channel_id()
     sent_message = await free_service.send_message_to_channel(
         text=data.get("post_text", ""),
         protect_content=protect_content,
-        reply_markup=get_interactive_post_kb(0, buttons),
+        reply_markup=get_interactive_post_kb(
+            reactions=buttons,
+            current_counts={},
+            message_id=0,
+            channel_id=channel_id or 0,
+        ),
         media_files=data.get("media_files", [])
     )
 
@@ -351,7 +357,12 @@ async def confirm_and_send_post(callback: CallbackQuery, state: FSMContext, sess
         await callback.bot.edit_message_reply_markup(
             channel_id,
             sent_message.message_id,
-            reply_markup=get_interactive_post_kb(sent_message.message_id, buttons),
+            reply_markup=get_interactive_post_kb(
+                reactions=buttons,
+                current_counts={},
+                message_id=sent_message.message_id,
+                channel_id=channel_id or 0,
+            ),
         )
     
     if sent_message:

--- a/mybot/keyboards/common.py
+++ b/mybot/keyboards/common.py
@@ -1,7 +1,11 @@
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.types import InlineKeyboardMarkup
+from typing import Dict
+import logging
 
 from utils.config import DEFAULT_REACTION_BUTTONS
+
+logger = logging.getLogger(__name__)
 
 
 def get_back_kb(callback_data: str = "admin_back"):
@@ -12,10 +16,10 @@ def get_back_kb(callback_data: str = "admin_back"):
 
 
 def get_interactive_post_kb(
+    reactions: list[str],
+    current_counts: Dict[str, int] | None,
     message_id: int,
-    raw_reactions: list[str],
     channel_id: int,
-    reaction_counts: dict[str, int] | None = None,
 ) -> InlineKeyboardMarkup:
     """
     Keyboard with reaction buttons for channel posts.
@@ -23,13 +27,16 @@ def get_interactive_post_kb(
     """
     builder = InlineKeyboardBuilder()
 
-    if reaction_counts is None:
-        reaction_counts = {}
+    if not isinstance(current_counts, dict):
+        logger.error(
+            f"Expected current_counts to be a dict, but got {type(current_counts)}"
+        )
+        current_counts = {}
 
-    reactions_to_use = raw_reactions if raw_reactions else DEFAULT_REACTION_BUTTONS
+    reactions_to_use = reactions if reactions else DEFAULT_REACTION_BUTTONS
 
     for emoji in reactions_to_use[:10]:
-        count = reaction_counts.get(emoji, 0)
+        count = current_counts.get(emoji, 0)
         display = f"{emoji} {count}"
         callback_data = f"ip_{channel_id}_{message_id}_{emoji}"
         builder.button(text=display, callback_data=callback_data)

--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -74,9 +74,9 @@ class MessageService:
             counts = await self.get_reaction_counts(real_message_id)
 
             updated_markup = get_interactive_post_kb(
+                reactions=raw_reactions,
+                current_counts=counts,
                 message_id=real_message_id,
-                raw_reactions=raw_reactions,
-                reaction_counts=counts,
                 channel_id=target_channel_id,
             )
 
@@ -177,7 +177,12 @@ class MessageService:
         raw_reactions, _ = await self.channel_service.get_reactions_and_points(chat_id)
 
         try:
-            markup_to_edit = get_interactive_post_kb(message_id, raw_reactions, counts, chat_id)
+            markup_to_edit = get_interactive_post_kb(
+                reactions=raw_reactions,
+                current_counts=counts,
+                message_id=message_id,
+                channel_id=chat_id,
+            )
             logger.info(f"DEBUG: Markup being sent for update: {markup_to_edit}")
 
             await self.bot.edit_message_reply_markup(


### PR DESCRIPTION
## Summary
- check that `current_counts` is a dict when building interactive post keyboards
- call `get_interactive_post_kb` with correct arguments in message service
- pass channel id when creating keyboards in free channel admin flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3f3d89c08329a7eed39584f8a1f3