### PR TITLE
Add publication mode test handler

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -21,6 +21,7 @@ from handlers.admin.auction_admin import router as auction_admin_router
 from handlers import setup as setup_handlers # ¡IMPORTACIÓN CLAVE!
 
 from handlers.free_channel_admin import router as free_channel_admin_router
+from handlers.publication_test import router as publication_test_router
 
 from utils.config import BOT_TOKEN, VIP_CHANNEL_ID
 from services import (
@@ -82,6 +83,7 @@ async def main() -> None:
     dp.include_router(admin_router)
     dp.include_router(auction_admin_router)
     dp.include_router(free_channel_admin_router)  # Nuevo router para canal gratuito
+    dp.include_router(publication_test_router)
     dp.include_router(vip.router)
     dp.include_router(gamification.router)
     dp.include_router(auction_user_router)

--- a/mybot/handlers/publication_test.py
+++ b/mybot/handlers/publication_test.py
@@ -1,0 +1,55 @@
+import logging
+from aiogram import Router, Bot, F
+from aiogram.filters import Command
+from aiogram.types import Message, CallbackQuery
+
+from utils.config import Config
+from utils.user_roles import is_admin
+from keyboards.publication_test_kb import (
+    get_publication_test_kb,
+    get_publication_test_completed_kb,
+)
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+
+@router.message(Command("test_publicacion"))
+async def cmd_test_publicacion(message: Message, bot: Bot) -> None:
+    """Send a test message to the configured channel to check publication mode."""
+    if not is_admin(message.from_user.id):
+        return
+
+    channel_id = Config.CHANNEL_ID
+    logger.info(
+        "Enviando mensaje de test_publicacion al canal %s por solicitud de %s",
+        channel_id,
+        message.from_user.id,
+    )
+
+    await bot.send_message(
+        chat_id=channel_id,
+        text="\U0001F9EA Test de publicación desde el bot. Pulsa el botón para confirmar.",
+        reply_markup=get_publication_test_kb(),
+    )
+    await message.answer("Mensaje de prueba enviado al canal.")
+
+
+@router.callback_query(F.data == "confirmar_test_publicacion")
+async def cb_confirmar_test(callback: CallbackQuery, bot: Bot) -> None:
+    """Handle confirmation of the publication test."""
+    logger.info(
+        "Confirmación de test_publicacion recibida de usuario %s", callback.from_user.id
+    )
+    text = (
+        f"{callback.message.text}\n\n\u2714\uFE0F Confirmado"
+        if callback.message and callback.message.text
+        else "\u2714\uFE0F Confirmado"
+    )
+    await bot.edit_message_text(
+        chat_id=callback.message.chat.id,
+        message_id=callback.message.message_id,
+        text=text,
+        reply_markup=get_publication_test_completed_kb(),
+    )
+    await callback.answer("Test confirmado")

--- a/mybot/keyboards/publication_test_kb.py
+++ b/mybot/keyboards/publication_test_kb.py
@@ -1,0 +1,18 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+
+
+def get_publication_test_kb() -> InlineKeyboardMarkup:
+    """Keyboard with a single confirm button for the publication test."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="✅ Confirmar", callback_data="confirmar_test_publicacion")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_publication_test_completed_kb() -> InlineKeyboardMarkup:
+    """Keyboard shown once the test is confirmed."""
+    builder = InlineKeyboardBuilder()
+    builder.button(text="Test completado", callback_data="test_done")
+    builder.adjust(1)
+    return builder.as_markup()


### PR DESCRIPTION
## Summary
- add `publication_test` handler and keyboards
- support `/test_publicacion` command to verify channel posting mode
- wire publication test router into bot startup

## Testing
- `python -m py_compile mybot/keyboards/publication_test_kb.py mybot/handlers/publication_test.py mybot/bot.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_685b92c67a9c8329820eac0c2a7d2899