### PR TITLE
Secure inline edits with message validation

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -14,7 +14,7 @@ from handlers.user import start_token
 from handlers.vip import menu as vip
 from handlers.vip import gamification
 from handlers.vip.auction_user import router as auction_user_router
-from handlers.interactive_post import router as interactive_post_router
+from handlers.reaction_callback import router as reaction_callback_router
 from handlers.admin import admin_router
 from handlers.admin.auction_admin import router as auction_admin_router
 
@@ -87,7 +87,7 @@ async def main() -> None:
     dp.include_router(vip.router)
     dp.include_router(gamification.router)
     dp.include_router(auction_user_router)
-    dp.include_router(interactive_post_router)
+    dp.include_router(reaction_callback_router)
     dp.include_router(daily_gift.router)
     dp.include_router(minigames.router)
     dp.include_router(free_user.router)

--- a/mybot/handlers/free_channel_admin.py
+++ b/mybot/handlers/free_channel_admin.py
@@ -11,7 +11,7 @@ from utils.user_roles import is_admin
 from utils.menu_manager import menu_manager
 from services.free_channel_service import FreeChannelService
 from services.config_service import ConfigService
-from keyboards.common import get_interactive_post_kb
+from keyboards.inline_post_kb import get_reaction_kb
 from keyboards.free_channel_admin_kb import (
     get_free_channel_admin_kb,
     get_wait_time_selection_kb,
@@ -343,7 +343,7 @@ async def confirm_and_send_post(callback: CallbackQuery, state: FSMContext, sess
     sent_message = await free_service.send_message_to_channel(
         text=data.get("post_text", ""),
         protect_content=protect_content,
-        reply_markup=get_interactive_post_kb(
+        reply_markup=get_reaction_kb(
             reactions=buttons,
             current_counts={},
             message_id=0,
@@ -355,9 +355,9 @@ async def confirm_and_send_post(callback: CallbackQuery, state: FSMContext, sess
     if sent_message:
         channel_id = await config.get_free_channel_id()
         await callback.bot.edit_message_reply_markup(
-            channel_id,
-            sent_message.message_id,
-            reply_markup=get_interactive_post_kb(
+            chat_id=channel_id,
+            message_id=sent_message.message_id,
+            reply_markup=get_reaction_kb(
                 reactions=buttons,
                 current_counts={},
                 message_id=sent_message.message_id,

--- a/mybot/handlers/reaction_callback.py
+++ b/mybot/handlers/reaction_callback.py
@@ -1,18 +1,22 @@
+import logging
+
 from aiogram import Router, F, Bot
 from aiogram.types import CallbackQuery
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.message_service import MessageService
 from services.channel_service import ChannelService
+from services.message_registry import validate_message
 from utils.messages import BOT_MESSAGES
 
 router = Router()
+logger = logging.getLogger(__name__)
 
 
 @router.callback_query(F.data.startswith("ip_"))
-async def handle_interactive_post_callback(
+async def handle_reaction_callback(
     callback: CallbackQuery, session: AsyncSession, bot: Bot
-):
+) -> None:
     parts = callback.data.split("_")
     if len(parts) < 4:
         return await callback.answer()
@@ -28,6 +32,21 @@ async def handle_interactive_post_callback(
         return await callback.answer()
 
     reaction_type = parts[3]
+
+    if not callback.message:
+        return await callback.answer()
+
+    chat_id = callback.message.chat.id
+    valid = validate_message(chat_id, message_id)
+    logger.info(
+        "Edit attempt chat_id=%s message_id=%s valid=%s", chat_id, message_id, valid
+    )
+
+    if not valid:
+        logger.warning(
+            "[ERROR] El mensaje que se intenta editar no fue enviado por este bot o el chat_id es incorrecto."
+        )
+        return await callback.answer()
 
     service = MessageService(session, bot)
     channel_service = ChannelService(session)
@@ -54,11 +73,10 @@ async def handle_interactive_post_callback(
     from services.mission_service import MissionService
     mission_service = MissionService(session)
     await mission_service.update_progress(callback.from_user.id, "reaction", bot=bot)
-    chat_id_str = str(callback.message.chat.id)
-    await service.update_reaction_markup(chat_id_str, message_id)
+
+    await service.update_reaction_markup(chat_id, message_id)
     await callback.answer(BOT_MESSAGES["reaction_registered_points"].format(points=points))
     await bot.send_message(
         callback.from_user.id,
         BOT_MESSAGES["reaction_registered_points"].format(points=points),
     )
-

--- a/mybot/keyboards/inline_post_kb.py
+++ b/mybot/keyboards/inline_post_kb.py
@@ -1,0 +1,39 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+from typing import Dict
+import logging
+
+from utils.config import DEFAULT_REACTION_BUTTONS
+
+logger = logging.getLogger(__name__)
+
+
+def get_reaction_kb(
+    reactions: list[str],
+    current_counts: Dict[str, int] | None,
+    message_id: int,
+    channel_id: int,
+) -> InlineKeyboardMarkup:
+    """Build inline keyboard for reaction buttons."""
+    builder = InlineKeyboardBuilder()
+
+    if not isinstance(current_counts, dict):
+        logger.error(
+            "Expected current_counts to be a dict, got %s", type(current_counts)
+        )
+        current_counts = {}
+
+    reactions_to_use = reactions if reactions else DEFAULT_REACTION_BUTTONS
+
+    for emoji in reactions_to_use[:10]:
+        count = current_counts.get(emoji, 0)
+        display = f"{emoji} {count}"
+        callback_data = f"ip_{channel_id}_{message_id}_{emoji}"
+        builder.button(text=display, callback_data=callback_data)
+
+    keyboard_data = builder.export()
+    if keyboard_data:
+        num_buttons = sum(len(row) for row in keyboard_data)
+        builder.adjust(num_buttons if num_buttons <= 4 else 4)
+
+    return builder.as_markup()

--- a/mybot/services/free_channel_service.py
+++ b/mybot/services/free_channel_service.py
@@ -23,6 +23,7 @@ from sqlalchemy import select, func
 
 from database.models import PendingChannelRequest, User, BotConfig
 from services.config_service import ConfigService
+from services.message_registry import store_message
 from utils.text_utils import sanitize_text
 
 logger = logging.getLogger(__name__)
@@ -363,6 +364,8 @@ class FreeChannelService:
                 )
             
             logger.info(f"Message sent to free channel: {sent_message.message_id}")
+            if reply_markup:
+                store_message(free_channel_id, sent_message.message_id)
             return sent_message
             
         except Exception as e:

--- a/mybot/services/message_registry.py
+++ b/mybot/services/message_registry.py
@@ -1,0 +1,32 @@
+import logging
+from typing import Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+# In-memory storage of messages sent by the bot
+_SENT_MESSAGES: Set[Tuple[int, int]] = set()
+
+
+def store_message(chat_id: int | str, message_id: int) -> None:
+    """Store chat_id and message_id for a message sent by the bot."""
+    try:
+        chat_int = int(chat_id)
+    except (TypeError, ValueError):
+        logger.error(f"Invalid chat_id provided for store_message: {chat_id}")
+        return
+    _SENT_MESSAGES.add((chat_int, message_id))
+    logger.info(f"Stored message ({chat_int}, {message_id})")
+
+
+def validate_message(chat_id: int | str, message_id: int) -> bool:
+    """Return True if the message pair exists in the store."""
+    try:
+        chat_int = int(chat_id)
+    except (TypeError, ValueError):
+        logger.error(f"Invalid chat_id provided for validate_message: {chat_id}")
+        return False
+    valid = (chat_int, message_id) in _SENT_MESSAGES
+    logger.info(
+        f"Validation attempt for chat_id={chat_int}, message_id={message_id}: {valid}"
+    )
+    return valid


### PR DESCRIPTION
## Summary
- store sent messages for later validation
- add reaction callback handler with validation
- create inline keyboard builder module
- update services and handlers to use the registry and new keyboards
- include new router in bot setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b97a2a1748329ba4b76d5ef4e0fae