### PR TITLE
Refactor mission tracking models

### DIFF
--- a/mybot/services/achievement_service.py
+++ b/mybot/services/achievement_service.py
@@ -12,8 +12,8 @@ from database.models import (
     VipSubscription,
     Badge,
     UserBadge,
-    UserProgress,
-    UserMission,
+    UserStats,
+    UserMissionEntry,
 )
 
 PREDEFINED_ACHIEVEMENTS = [
@@ -120,7 +120,7 @@ class AchievementService:
 
     # ----- Badge related methods -----
     async def _badge_condition_met(self, user_id: int, badge: Badge) -> bool:
-        progress = await self.session.get(UserProgress, user_id)
+        progress = await self.session.get(UserStats, user_id)
         if not progress:
             return False
         if badge.condition_type == "messages":
@@ -128,9 +128,9 @@ class AchievementService:
         if badge.condition_type == "login_streak":
             return progress.checkin_streak >= badge.condition_value
         if badge.condition_type == "missions":
-            stmt = select(func.count()).select_from(UserMission).where(
-                UserMission.user_id == user_id,
-                UserMission.completed == True,
+            stmt = select(func.count()).select_from(UserMissionEntry).where(
+                UserMissionEntry.user_id == user_id,
+                UserMissionEntry.completed == True,
             )
             count = (await self.session.execute(stmt)).scalar() or 0
             return count >= badge.condition_value

--- a/mybot/services/badge_service.py
+++ b/mybot/services/badge_service.py
@@ -2,7 +2,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from aiogram import Bot
 
-from database.models import Badge, UserBadge, User, UserProgress
+from database.models import Badge, UserBadge, User, UserStats
 import re
 
 class BadgeService:
@@ -40,7 +40,7 @@ class BadgeService:
         await self.session.commit()
         return True
 
-    async def check_badges(self, user: User, progress: UserProgress, bot: Bot | None = None):
+    async def check_badges(self, user: User, progress: UserStats, bot: Bot | None = None):
         badges = await self.list_badges()
         for badge in badges:
             stmt = select(UserBadge).where(

--- a/mybot/services/daily_gift_service.py
+++ b/mybot/services/daily_gift_service.py
@@ -1,7 +1,7 @@
 import datetime
 from aiogram import Bot
 from sqlalchemy.ext.asyncio import AsyncSession
-from database.models import UserProgress
+from database.models import UserStats
 from .point_service import PointService
 from .config_service import ConfigService
 
@@ -13,9 +13,9 @@ class DailyGiftService:
 
     async def claim_gift(self, user_id: int, bot: Bot) -> tuple[bool, int]:
         """Attempt to claim the daily gift. Returns (claimed, points_awarded)."""
-        progress = await self.session.get(UserProgress, user_id)
+        progress = await self.session.get(UserStats, user_id)
         if not progress:
-            progress = UserProgress(user_id=user_id)
+            progress = UserStats(user_id=user_id)
             self.session.add(progress)
             await self.session.commit()
         now = datetime.datetime.utcnow()


### PR DESCRIPTION
## Summary
- consolidate mission tracking into `UserMissionEntry`
- rename `UserProgress` to `UserStats`
- remove `ReactionChallenge` model and integrate with missions
- drop `channel_reactions` from users
- add lore piece system models
- adjust services to new model names and behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bcaa0b1c083298ec2f2351ebe5e4d