### PR TITLE
Implement basic paginated mission admin

### DIFF
--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -5,6 +5,7 @@ from .config_menu import router as config_router
 from .channel_admin import router as channel_admin_router
 from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
+from .missions_admin import router as missions_admin_router
 from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
 
@@ -16,6 +17,7 @@ __all__ = [
     "channel_admin_router",
     "subscription_plans_router",
     "game_admin_router",
+    "missions_admin_router",
     "event_admin_router",
     "admin_config_router",
 ]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -211,8 +211,9 @@ async def handle_kinky_game_button_from_main(callback: CallbackQuery, session: A
     if not is_admin(callback.from_user.id):
         return await callback.answer("Acceso denegado", show_alert=True)
     
-    # Simplemente llamamos al handler que ya muestra el menú completo de gamificación
-    await handle_gamification_content_menu(callback, session)
+    # Mostrar el nuevo panel de administración de juego
+    from .missions_admin import admin_main_menu
+    await admin_main_menu(callback)
     # No es necesario un callback.answer() aquí porque handle_gamification_content_menu ya lo hace.
 
 

--- a/mybot/handlers/admin/missions_admin.py
+++ b/mybot/handlers/admin/missions_admin.py
@@ -1,0 +1,80 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from utils.user_roles import is_admin
+from utils.pagination import paginate
+from utils.keyboard_utils import (
+    get_game_admin_main_keyboard,
+    get_admin_mission_list_keyboard,
+    get_back_keyboard,
+)
+from utils.admin_state import MissionAdminStates
+from services.mission_service import MissionService
+from database.models import Mission
+
+router = Router()
+
+
+async def show_missions_page(message: Message, session: AsyncSession, page: int) -> None:
+    stmt = select(Mission).order_by(Mission.created_at)
+    missions, total, has_prev, has_next = await paginate(session, stmt, page)
+    lines = [f"📌 Misiones (página {page + 1})"]
+    for m in missions:
+        lines.append(f"- {m.name} [{m.id}]")
+    kb = get_admin_mission_list_keyboard(missions, page, has_prev, has_next)
+    await message.edit_text("\n".join(lines), reply_markup=kb)
+
+
+@router.callback_query(F.data == "game_admin_main")
+async def admin_main_menu(callback: CallbackQuery):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text("Selecciona una entidad a gestionar:", reply_markup=get_game_admin_main_keyboard())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_manage_missions")
+async def admin_manage_missions(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await show_missions_page(callback.message, session, 0)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("missions_page:"))
+async def missions_page(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    page = int(callback.data.split(":")[-1])
+    await show_missions_page(callback.message, session, page)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("edit_mission:"))
+async def edit_mission_start(callback: CallbackQuery, session: AsyncSession, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    mission_id = callback.data.split(":")[-1]
+    mission = await MissionService(session).get_mission_by_id(mission_id)
+    if not mission:
+        return await callback.answer("Misión no encontrada", show_alert=True)
+    await state.update_data(mission_id=mission_id, page=0)
+    await callback.message.answer(f"Nuevo nombre para {mission.name}:", reply_markup=get_back_keyboard("admin_manage_missions"))
+    await state.set_state(MissionAdminStates.editing_name)
+    await callback.answer()
+
+
+@router.message(MissionAdminStates.editing_name)
+async def process_edit_name(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    mission_id = data.get("mission_id")
+    page = data.get("page", 0)
+    await MissionService(session).update_mission(mission_id, name=message.text)
+    await message.answer("Misión actualizada")
+    await state.clear()
+    await show_missions_page(message, session, page)

--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -211,6 +211,18 @@ class MissionService:
             return True
         return False
 
+    async def update_mission(self, mission_id: str, **fields) -> Mission | None:
+        """Update mission fields and return the updated mission."""
+        mission = await self.session.get(Mission, mission_id)
+        if not mission:
+            return None
+        for key, value in fields.items():
+            if hasattr(mission, key) and value is not None:
+                setattr(mission, key, value)
+        await self.session.commit()
+        await self.session.refresh(mission)
+        return mission
+
     async def update_progress(
         self,
         user_id: int,

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -92,6 +92,17 @@ class AdminMissionStates(StatesGroup):
     creating_mission_duration = State()
 
 
+class MissionAdminStates(StatesGroup):
+    """States for editing existing missions."""
+
+    editing_name = State()
+    editing_description = State()
+    editing_type = State()
+    editing_target = State()
+    editing_reward = State()
+    editing_duration = State()
+
+
 class AdminVipMissionStates(StatesGroup):
     """Simplified mission creation flow from the VIP config menu."""
 

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -580,3 +580,40 @@ def get_badge_selection_keyboard(badges: list) -> InlineKeyboardMarkup:
         [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_content_badges")]
     )
     return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def get_game_admin_main_keyboard() -> InlineKeyboardMarkup:
+    """Main menu keyboard for game administration."""
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="📌 Gestionar Misiones", callback_data="admin_manage_missions")],
+            [InlineKeyboardButton(text="📈 Gestionar Niveles", callback_data="admin_content_levels")],
+            [InlineKeyboardButton(text="🧩 Gestionar Pistas", callback_data="admin_manage_lorepieces")],
+            [InlineKeyboardButton(text="🎁 Gestionar Recompensas", callback_data="admin_content_rewards")],
+            [InlineKeyboardButton(text="👥 Gestionar Usuarios", callback_data="admin_manage_users")],
+            [InlineKeyboardButton(text="🏛️ Gestionar Subastas", callback_data="admin_auction_main")],
+            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_main_menu")],
+        ]
+    )
+    return keyboard
+
+
+def get_admin_mission_list_keyboard(missions: list, page: int, has_prev: bool, has_next: bool) -> InlineKeyboardMarkup:
+    """Keyboard for a paginated list of missions."""
+    rows: list[list[InlineKeyboardButton]] = []
+    for m in missions:
+        rows.append([
+            InlineKeyboardButton(text="✏️", callback_data=f"edit_mission:{m.id}"),
+            InlineKeyboardButton(text="🗑", callback_data=f"delete_mission:{m.id}"),
+            InlineKeyboardButton(text="✅" if m.is_active else "❌", callback_data=f"toggle_mission:{m.id}"),
+        ])
+    nav: list[InlineKeyboardButton] = []
+    if has_prev:
+        nav.append(InlineKeyboardButton(text="⬅️", callback_data=f"missions_page:{page-1}"))
+    if has_next:
+        nav.append(InlineKeyboardButton(text="➡️", callback_data=f"missions_page:{page+1}"))
+    if nav:
+        rows.append(nav)
+    rows.append([InlineKeyboardButton(text="➕ Crear Nueva", callback_data="admin_create_mission")])
+    rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="game_admin_main")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)

--- a/mybot/utils/pagination.py
+++ b/mybot/utils/pagination.py
@@ -1,0 +1,12 @@
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+async def paginate(session: AsyncSession, stmt, page: int = 0, page_size: int = 5):
+    """Return items for a page with total count and navigation flags."""
+    total_stmt = select(func.count()).select_from(stmt.subquery())
+    total = (await session.execute(total_stmt)).scalar_one()
+    result = await session.execute(stmt.offset(page * page_size).limit(page_size))
+    items = result.scalars().all()
+    has_prev = page > 0
+    has_next = (page + 1) * page_size < total
+    return items, total, has_prev, has_next


### PR DESCRIPTION
## Summary
- add pagination helper
- expose new `MissionAdminStates` for editing missions
- extend `MissionService` with `update_mission`
- create admin mission management handlers with basic edit flow
- add keyboards for game admin menus
- wire new router into admin package

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c21a9c4548329b027cc9e473ddf26