### PR TITLE
Add independent admin panel and mission management

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -15,7 +15,7 @@ from handlers.vip import menu as vip
 from handlers.vip import gamification
 from handlers.vip.auction_user import router as auction_user_router
 from handlers.reaction_callback import router as reaction_callback_router
-from handlers.admin import admin_router
+from handlers.admin import admin_router, admin_main_router
 from handlers.admin.auction_admin import router as auction_admin_router
 from handlers.lore_handlers import router as lore_router
 
@@ -81,6 +81,7 @@ async def main() -> None:
 
     dp.include_router(start_token)
     dp.include_router(start.router)
+    dp.include_router(admin_main_router)
     dp.include_router(admin_router)
     dp.include_router(auction_admin_router)
     dp.include_router(free_channel_admin_router)  # Nuevo router para canal gratuito

--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -1,4 +1,5 @@
 from .admin_menu import router as admin_router
+from .admin_main import router as admin_main_router
 from .vip_menu import router as vip_router
 from .free_menu import router as free_router
 from .config_menu import router as config_router
@@ -10,6 +11,7 @@ from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
 
 __all__ = [
+    "admin_main_router",
     "admin_router",
     "vip_router",
     "free_router",

--- a/mybot/handlers/admin/admin_main.py
+++ b/mybot/handlers/admin/admin_main.py
@@ -1,0 +1,27 @@
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton
+
+from utils.user_roles import is_admin
+
+router = Router()
+
+
+def get_admin_main_keyboard() -> InlineKeyboardMarkup:
+    keyboard = [
+        [InlineKeyboardButton(text="Gestionar Misiones", callback_data="admin_manage_missions")],
+        [InlineKeyboardButton(text="Gestionar Niveles", callback_data="admin_manage_levels")],
+        [InlineKeyboardButton(text="Gestionar Pistas", callback_data="admin_manage_lore_pieces")],
+        [InlineKeyboardButton(text="Volver al Menú Principal del Bot", callback_data="main_menu")],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+@router.message(Command("admin") | Command("panel_admin"))
+async def admin_panel(message: Message):
+    if not is_admin(message.from_user.id):
+        return
+    await message.answer(
+        "Bienvenido al Panel de Administración. Seleccione una opción:",
+        reply_markup=get_admin_main_keyboard(),
+    )

--- a/mybot/handlers/admin/missions_admin.py
+++ b/mybot/handlers/admin/missions_admin.py
@@ -1,39 +1,59 @@
 from aiogram import Router, F
-from aiogram.types import CallbackQuery, Message
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from utils.user_roles import is_admin
 from utils.pagination import paginate
-from utils.keyboard_utils import (
-    get_game_admin_main_keyboard,
-    get_admin_mission_list_keyboard,
-    get_back_keyboard,
-)
 from utils.admin_state import MissionAdminStates
 from services.mission_service import MissionService
-from database.models import Mission
+from database.models import Mission, LorePiece
 
 router = Router()
 
 
+def build_mission_actions_keyboard(mission: Mission) -> list[InlineKeyboardButton]:
+    return [
+        InlineKeyboardButton(text="Editar", callback_data=f"edit_mission:{mission.id}"),
+        InlineKeyboardButton(text="Eliminar", callback_data=f"delete_mission:{mission.id}"),
+        InlineKeyboardButton(text="Ver Detalles", callback_data=f"view_mission_details:{mission.id}"),
+        InlineKeyboardButton(
+            text="Desactivar" if mission.is_active else "Activar",
+            callback_data=f"toggle_mission_active:{mission.id}",
+        ),
+    ]
+
+
+def build_missions_list_keyboard(missions: list[Mission], page: int, has_prev: bool, has_next: bool) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    for m in missions:
+        rows.append(build_mission_actions_keyboard(m))
+    nav: list[InlineKeyboardButton] = []
+    if has_prev:
+        nav.append(InlineKeyboardButton(text="⬅️", callback_data=f"missions_page:{page-1}"))
+    if has_next:
+        nav.append(InlineKeyboardButton(text="➡️", callback_data=f"missions_page:{page+1}"))
+    if nav:
+        rows.append(nav)
+    rows.append([InlineKeyboardButton(text="Crear Nueva Misión", callback_data="create_mission")])
+    rows.append([InlineKeyboardButton(text="Volver al Menú Admin", callback_data="admin_main_menu")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+async def safe_edit(message: Message, text: str, reply_markup: InlineKeyboardMarkup | None = None):
+    if message.text != text or str(message.reply_markup) != str(reply_markup):
+        await message.edit_text(text, reply_markup=reply_markup)
+
+
 async def show_missions_page(message: Message, session: AsyncSession, page: int) -> None:
     stmt = select(Mission).order_by(Mission.created_at)
-    missions, total, has_prev, has_next = await paginate(session, stmt, page)
+    missions, _, has_prev, has_next = await paginate(session, stmt, page)
     lines = [f"📌 Misiones (página {page + 1})"]
     for m in missions:
-        lines.append(f"- {m.name} [{m.id}]")
-    kb = get_admin_mission_list_keyboard(missions, page, has_prev, has_next)
-    await message.edit_text("\n".join(lines), reply_markup=kb)
-
-
-@router.callback_query(F.data == "game_admin_main")
-async def admin_main_menu(callback: CallbackQuery):
-    if not is_admin(callback.from_user.id):
-        return await callback.answer()
-    await callback.message.edit_text("Selecciona una entidad a gestionar:", reply_markup=get_game_admin_main_keyboard())
-    await callback.answer()
+        lines.append(f"ID: {m.id} | Título: {m.name} | Tipo: {m.type}")
+    markup = build_missions_list_keyboard(missions, page, has_prev, has_next)
+    await safe_edit(message, "\n".join(lines), reply_markup=markup)
 
 
 @router.callback_query(F.data == "admin_manage_missions")
@@ -53,28 +73,215 @@ async def missions_page(callback: CallbackQuery, session: AsyncSession):
     await callback.answer()
 
 
-@router.callback_query(F.data.startswith("edit_mission:"))
-async def edit_mission_start(callback: CallbackQuery, session: AsyncSession, state: FSMContext):
+@router.callback_query(F.data.startswith("view_mission_details:"))
+async def view_mission_details(callback: CallbackQuery, session: AsyncSession):
     if not is_admin(callback.from_user.id):
         return await callback.answer()
     mission_id = callback.data.split(":")[-1]
     mission = await MissionService(session).get_mission_by_id(mission_id)
     if not mission:
         return await callback.answer("Misión no encontrada", show_alert=True)
-    await state.update_data(mission_id=mission_id, page=0)
-    await callback.message.answer(f"Nuevo nombre para {mission.name}:", reply_markup=get_back_keyboard("admin_manage_missions"))
-    await state.set_state(MissionAdminStates.editing_name)
+    lore_title = "Ninguna"
+    if mission.unlocks_lore_piece_code:
+        stmt = select(LorePiece).where(LorePiece.code_name == mission.unlocks_lore_piece_code)
+        lore_piece = (await session.execute(stmt)).scalar_one_or_none()
+        lore_title = lore_piece.title if lore_piece else "Ninguna"
+    text = (
+        f"<b>{mission.name}</b> (ID: {mission.id})\n\n"
+        f"Tipo: {mission.type}\n"
+        f"Puntos: {mission.reward_points}\n"
+        f"Descripción: {mission.description or 'Sin descripción'}\n"
+        f"Recompensa de Pista: {lore_title}\n"
+        f"Estado: {'Activa' if mission.is_active else 'Inactiva'}"
+    )
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Editar Misión", callback_data=f"edit_mission:{mission.id}")],
+            [InlineKeyboardButton(text="Eliminar Misión", callback_data=f"delete_mission:{mission.id}")],
+            [InlineKeyboardButton(text="Volver a Misiones", callback_data="admin_manage_missions")],
+        ]
+    )
+    await safe_edit(callback.message, text, reply_markup=kb)
     await callback.answer()
 
 
-@router.message(MissionAdminStates.editing_name)
-async def process_edit_name(message: Message, state: FSMContext, session: AsyncSession):
+@router.callback_query(F.data == "create_mission")
+async def create_mission(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await state.clear()
+    kb = InlineKeyboardMarkup(inline_keyboard=[[InlineKeyboardButton(text="Cancelar", callback_data="admin_manage_missions")]])
+    await callback.message.answer("Ingrese el título de la misión:", reply_markup=kb)
+    await state.set_state(MissionAdminStates.waiting_for_name)
+    await callback.answer()
+
+
+@router.message(MissionAdminStates.waiting_for_name)
+async def mission_set_name(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(name=message.text)
+    await message.answer("Tipo de misión (reaction, daily, weekly, one_time):")
+    await state.set_state(MissionAdminStates.waiting_for_type)
+
+
+@router.message(MissionAdminStates.waiting_for_type)
+async def mission_set_type(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(mission_type=message.text)
+    await message.answer("Puntos de recompensa:")
+    await state.set_state(MissionAdminStates.waiting_for_points)
+
+
+@router.message(MissionAdminStates.waiting_for_points)
+async def mission_set_points(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    try:
+        points = int(message.text)
+    except ValueError:
+        await message.answer("Ingrese un número válido de puntos:")
+        return
+    await state.update_data(points=points)
+    await message.answer("Descripción de la misión:")
+    await state.set_state(MissionAdminStates.waiting_for_description)
+
+
+@router.message(MissionAdminStates.waiting_for_description)
+async def mission_set_description(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(description=message.text)
+    await message.answer("Código de la pista de recompensa (o '-' para ninguna):")
+    await state.set_state(MissionAdminStates.waiting_for_lore_piece_code)
+
+
+@router.message(MissionAdminStates.waiting_for_lore_piece_code)
+async def mission_finish_creation(message: Message, state: FSMContext, session: AsyncSession):
     if not is_admin(message.from_user.id):
         return
     data = await state.get_data()
-    mission_id = data.get("mission_id")
-    page = data.get("page", 0)
-    await MissionService(session).update_mission(mission_id, name=message.text)
-    await message.answer("Misión actualizada")
+    lore_code = message.text.strip()
+    lore_code = lore_code if lore_code != "-" else None
+    try:
+        mission = await MissionService(session).create_mission(
+            name=data["name"],
+            description=data["description"],
+            mission_type=data["mission_type"],
+            target_value=1,
+            reward_points=data["points"],
+            duration_days=0,
+            requires_action=False,
+            action_data=None,
+        )
+        if lore_code:
+            await MissionService(session).update_mission(mission.id, unlocks_lore_piece_code=lore_code)
+        await message.answer(f"¡Misión '{mission.name}' creada exitosamente!")
+    except Exception as e:
+        await message.answer(f"Error al crear misión: {e}")
     await state.clear()
-    await show_missions_page(message, session, page)
+
+
+@router.callback_query(F.data.startswith("edit_mission:"))
+async def edit_mission(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    mission_id = callback.data.split(":")[-1]
+    await state.update_data(mission_id=mission_id)
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Título", callback_data=f"edit_mission_field:name:{mission_id}")],
+            [InlineKeyboardButton(text="Tipo", callback_data=f"edit_mission_field:type:{mission_id}")],
+            [InlineKeyboardButton(text="Puntos", callback_data=f"edit_mission_field:points:{mission_id}")],
+            [InlineKeyboardButton(text="Descripción", callback_data=f"edit_mission_field:description:{mission_id}")],
+            [InlineKeyboardButton(text="Pista", callback_data=f"edit_mission_field:lore:{mission_id}")],
+            [InlineKeyboardButton(text="Volver", callback_data="admin_manage_missions")],
+        ]
+    )
+    await callback.message.edit_text("Seleccione el campo a editar:", reply_markup=kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("edit_mission_field:"))
+async def edit_mission_field(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    parts = callback.data.split(":")
+    field = parts[1]
+    mission_id = parts[2]
+    await state.update_data(mission_id=mission_id, field=field)
+    kb = InlineKeyboardMarkup(inline_keyboard=[[InlineKeyboardButton(text="Cancelar", callback_data="admin_manage_missions")]])
+    await callback.message.edit_text("Ingrese el nuevo valor:", reply_markup=kb)
+    await state.set_state(MissionAdminStates.editing_field)
+    await callback.answer()
+
+
+@router.message(MissionAdminStates.editing_field)
+async def save_field_value(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    mission_id = data["mission_id"]
+    field = data["field"]
+    value = message.text
+    update_kwargs = {}
+    if field == "points":
+        try:
+            value = int(value)
+        except ValueError:
+            await message.answer("Ingrese un número válido:")
+            return
+        update_kwargs["reward_points"] = value
+    elif field == "name":
+        update_kwargs["name"] = value
+    elif field == "type":
+        update_kwargs["type"] = value
+    elif field == "description":
+        update_kwargs["description"] = value
+    elif field == "lore":
+        update_kwargs["unlocks_lore_piece_code"] = value if value != "-" else None
+    await MissionService(session).update_mission(mission_id, **update_kwargs)
+    await message.answer("Campo actualizado.")
+    await state.clear()
+
+
+@router.callback_query(F.data.startswith("delete_mission:"))
+async def delete_mission(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    mission_id = callback.data.split(":")[-1]
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Sí, Eliminar", callback_data=f"confirm_delete_mission:{mission_id}")],
+            [InlineKeyboardButton(text="Cancelar", callback_data="admin_manage_missions")],
+        ]
+    )
+    await callback.message.edit_text("¿Estás seguro de que quieres eliminar esta misión?", reply_markup=kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("confirm_delete_mission:"))
+async def confirm_delete_mission(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    mission_id = callback.data.split(":")[-1]
+    svc = MissionService(session)
+    mission = await svc.get_mission_by_id(mission_id)
+    if mission:
+        await svc.delete_mission(mission_id)
+        await callback.message.edit_text(f"Misión '{mission.name}' eliminada.")
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("toggle_mission_active:"))
+async def toggle_mission_active(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    mission_id = callback.data.split(":")[-1]
+    service = MissionService(session)
+    mission = await service.get_mission_by_id(mission_id)
+    if not mission:
+        return await callback.answer("Misión no encontrada", show_alert=True)
+    await service.toggle_mission_status(mission_id, not mission.is_active)
+    await callback.answer(f"Misión '{mission.name}' ahora está {'Activa' if not mission.is_active else 'Inactiva'}.")

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -93,7 +93,15 @@ class AdminMissionStates(StatesGroup):
 
 
 class MissionAdminStates(StatesGroup):
-    """States for editing existing missions."""
+    """States for mission creation and editing."""
+
+    waiting_for_name = State()
+    waiting_for_type = State()
+    waiting_for_points = State()
+    waiting_for_description = State()
+    waiting_for_lore_piece_code = State()
+
+    editing_field = State()
 
     editing_name = State()
     editing_description = State()


### PR DESCRIPTION
## Summary
- create a new admin entrypoint via `/admin`
- refactor mission admin handlers with CRUD, pagination and FSM
- extend MissionAdminStates with creation states
- wire new routers in application

## Testing
- `python -m py_compile mybot/handlers/admin/admin_main.py mybot/handlers/admin/missions_admin.py mybot/utils/admin_state.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c3f05e9c48329a7f6ea1ac7dba167