### PR TITLE
Fix admin command filter

### DIFF
--- a/mybot/handlers/admin/admin_main.py
+++ b/mybot/handlers/admin/admin_main.py
@@ -17,7 +17,8 @@ def get_admin_main_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
-@router.message(Command("admin") | Command("panel_admin"))
+# Handle both /admin and /panel_admin commands
+@router.message(Command(commands=["admin", "panel_admin"]))
 async def admin_panel(message: Message):
     if not is_admin(message.from_user.id):
         return


### PR DESCRIPTION
## Summary
- support both `/admin` and `/panel_admin` commands with a single filter

## Testing
- `python -m py_compile mybot/handlers/admin/admin_main.py`


------
https://chatgpt.com/codex/tasks/task_e_685c46053fc08329a3e6ee96b64c395b