### PR TITLE
Refactor mission admin listing and main menu navigation

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -211,10 +211,11 @@ async def handle_kinky_game_button_from_main(callback: CallbackQuery, session: A
     if not is_admin(callback.from_user.id):
         return await callback.answer("Acceso denegado", show_alert=True)
     
-    # Mostrar el nuevo panel de administración de juego
-    from .missions_admin import admin_main_menu
-    await admin_main_menu(callback)
-    # No es necesario un callback.answer() aquí porque handle_gamification_content_menu ya lo hace.
+    # Mostrar el panel de administración de juego kinky
+    text = "Panel de Administración del Juego Kinky. Selecciona una opción:"
+    keyboard = get_admin_manage_content_keyboard()
+    await callback.message.edit_text(text, reply_markup=keyboard)
+    await callback.answer()
 
 
 @router.callback_query(F.data == "admin_bot_config")

--- a/mybot/handlers/admin/missions_admin.py
+++ b/mybot/handlers/admin/missions_admin.py
@@ -1,43 +1,35 @@
 from aiogram import Router, F
-from aiogram.types import CallbackQuery, Message
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
 from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from utils.user_roles import is_admin
-from utils.pagination import paginate
-from utils.keyboard_utils import (
-    get_game_admin_main_keyboard,
-    get_admin_mission_list_keyboard,
-    get_back_keyboard,
-)
-from utils.admin_state import MissionAdminStates
+from utils.pagination import get_paginated_list
+from utils.keyboard_utils import get_admin_mission_list_keyboard, get_back_keyboard
+from utils.admin_state import AdminMissionStates, MissionAdminStates
+from utils.message_utils import safe_edit_message
 from services.mission_service import MissionService
-from database.models import Mission
+from database.models import Mission, LorePiece
 
 router = Router()
 
 
 async def show_missions_page(message: Message, session: AsyncSession, page: int) -> None:
     stmt = select(Mission).order_by(Mission.created_at)
-    missions, total, has_prev, has_next = await paginate(session, stmt, page)
-    lines = [f"📌 Misiones (página {page + 1})"]
+    missions, has_prev, has_next, total_pages = await get_paginated_list(session, stmt, page)
+    lines = [f"📌 Misiones (Página {page + 1} de {total_pages})"]
     for m in missions:
-        lines.append(f"- {m.name} [{m.id}]")
+        lines.append(
+            f"ID: {str(m.id)[:8]} | Título: {m.name} | Tipo: {m.type} | Puntos: {m.reward_points} | Activa: {'Sí' if m.is_active else 'No'}"
+        )
+    text = "\n".join(lines)
     kb = get_admin_mission_list_keyboard(missions, page, has_prev, has_next)
-    await message.edit_text("\n".join(lines), reply_markup=kb)
+    await safe_edit_message(message, text, kb)
 
 
-@router.callback_query(F.data == "game_admin_main")
-async def admin_main_menu(callback: CallbackQuery):
-    if not is_admin(callback.from_user.id):
-        return await callback.answer()
-    await callback.message.edit_text("Selecciona una entidad a gestionar:", reply_markup=get_game_admin_main_keyboard())
-    await callback.answer()
-
-
-@router.callback_query(F.data == "admin_manage_missions")
-async def admin_manage_missions(callback: CallbackQuery, session: AsyncSession):
+@router.callback_query(F.data == "admin_content_missions")
+async def list_missions(callback: CallbackQuery, session: AsyncSession):
     if not is_admin(callback.from_user.id):
         return await callback.answer()
     await show_missions_page(callback.message, session, 0)
@@ -48,22 +40,91 @@ async def admin_manage_missions(callback: CallbackQuery, session: AsyncSession):
 async def missions_page(callback: CallbackQuery, session: AsyncSession):
     if not is_admin(callback.from_user.id):
         return await callback.answer()
-    page = int(callback.data.split(":")[-1])
+    page = int(callback.data.split(":")[1])
     await show_missions_page(callback.message, session, page)
     await callback.answer()
 
 
-@router.callback_query(F.data.startswith("edit_mission:"))
-async def edit_mission_start(callback: CallbackQuery, session: AsyncSession, state: FSMContext):
+@router.callback_query(F.data.startswith("mission_view_details:"))
+async def mission_view_details(callback: CallbackQuery, session: AsyncSession):
     if not is_admin(callback.from_user.id):
         return await callback.answer()
-    mission_id = callback.data.split(":")[-1]
+    mission_id = callback.data.split(":")[1]
     mission = await MissionService(session).get_mission_by_id(mission_id)
     if not mission:
         return await callback.answer("Misión no encontrada", show_alert=True)
-    await state.update_data(mission_id=mission_id, page=0)
-    await callback.message.answer(f"Nuevo nombre para {mission.name}:", reply_markup=get_back_keyboard("admin_manage_missions"))
-    await state.set_state(MissionAdminStates.editing_name)
+
+    lore_text = ""
+    if mission.unlocks_lore_piece_code:
+        stmt = select(LorePiece).where(LorePiece.code_name == mission.unlocks_lore_piece_code)
+        lore = (await session.execute(stmt)).scalar_one_or_none()
+        if lore:
+            lore_text = f"Recompensa: {lore.title}"
+
+    lines = [
+        f"ID: {mission.id}",
+        f"Título: {mission.name}",
+        f"Descripción: {mission.description or '-'}",
+        f"Tipo: {mission.type}",
+        f"Puntos: {mission.reward_points}",
+        f"Activa: {'Sí' if mission.is_active else 'No'}",
+    ]
+    if lore_text:
+        lines.append(lore_text)
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Editar Misión", callback_data=f"mission_edit:{mission.id}")],
+            [InlineKeyboardButton(text="Eliminar Misión", callback_data=f"mission_delete:{mission.id}")],
+            [InlineKeyboardButton(text="Activar/Desactivar", callback_data=f"mission_toggle_active:{mission.id}")],
+            [InlineKeyboardButton(text="🔙 Volver a Misiones", callback_data="admin_content_missions")],
+        ]
+    )
+    await safe_edit_message(callback.message, "\n".join(lines), keyboard)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "mission_create")
+async def mission_create(callback: CallbackQuery, state: FSMContext):
+    from .game_admin import admin_start_create_mission
+    await admin_start_create_mission(callback, state)
+
+
+@router.callback_query(F.data.startswith("mission_edit:"))
+async def mission_edit(callback: CallbackQuery):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    mission_id = callback.data.split(":")[1]
+    text = "¿Qué campo deseas editar?"
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Título", callback_data=f"mission_edit_field:name:{mission_id}")],
+            [InlineKeyboardButton(text="Descripción", callback_data=f"mission_edit_field:description:{mission_id}")],
+            [InlineKeyboardButton(text="Puntos", callback_data=f"mission_edit_field:points:{mission_id}")],
+            [InlineKeyboardButton(text="🔙 Volver", callback_data=f"mission_view_details:{mission_id}")],
+        ]
+    )
+    await safe_edit_message(callback.message, text, kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("mission_edit_field:"))
+async def mission_edit_field(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    _, field, mission_id = callback.data.split(":")
+    prompts = {
+        "name": "Nuevo título de la misión:",
+        "description": "Nueva descripción:",
+        "points": "Nuevo valor de puntos:",
+    }
+    states = {
+        "name": MissionAdminStates.editing_name,
+        "description": MissionAdminStates.editing_description,
+        "points": MissionAdminStates.editing_reward,
+    }
+    await state.update_data(mission_id=mission_id)
+    await callback.message.edit_text(prompts[field], reply_markup=get_back_keyboard(f"mission_edit:{mission_id}"))
+    await state.set_state(states[field])
     await callback.answer()
 
 
@@ -73,8 +134,80 @@ async def process_edit_name(message: Message, state: FSMContext, session: AsyncS
         return
     data = await state.get_data()
     mission_id = data.get("mission_id")
-    page = data.get("page", 0)
     await MissionService(session).update_mission(mission_id, name=message.text)
     await message.answer("Misión actualizada")
     await state.clear()
-    await show_missions_page(message, session, page)
+
+
+@router.message(MissionAdminStates.editing_description)
+async def process_edit_description(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    mission_id = data.get("mission_id")
+    await MissionService(session).update_mission(mission_id, description=message.text)
+    await message.answer("Misión actualizada")
+    await state.clear()
+
+
+@router.message(MissionAdminStates.editing_reward)
+async def process_edit_reward(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    mission_id = data.get("mission_id")
+    try:
+        points = int(message.text)
+    except ValueError:
+        await message.answer("Ingresa un número válido")
+        return
+    await MissionService(session).update_mission(mission_id, reward_points=points)
+    await message.answer("Misión actualizada")
+    await state.clear()
+
+
+@router.callback_query(F.data.startswith("mission_delete:"))
+async def mission_delete(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    mission_id = callback.data.split(":")[1]
+    mission = await MissionService(session).get_mission_by_id(mission_id)
+    if not mission:
+        return await callback.answer("Misión no encontrada", show_alert=True)
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Sí, Eliminar", callback_data=f"mission_delete_confirm:{mission_id}")],
+            [InlineKeyboardButton(text="Cancelar", callback_data=f"mission_view_details:{mission_id}")],
+        ]
+    )
+    await safe_edit_message(callback.message, f"¿Eliminar permanentemente '{mission.name}'?", kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("mission_delete_confirm:"))
+async def mission_delete_confirm(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    mission_id = callback.data.split(":")[1]
+    mission = await MissionService(session).get_mission_by_id(mission_id)
+    if not mission:
+        return await callback.answer("Misión no encontrada", show_alert=True)
+    await MissionService(session).delete_mission(mission_id)
+    await callback.message.edit_text(f"Misión '{mission.name}' eliminada.")
+    await list_missions(callback, session)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("mission_toggle_active:"))
+async def mission_toggle_active(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    mission_id = callback.data.split(":")[1]
+    service = MissionService(session)
+    mission = await service.get_mission_by_id(mission_id)
+    if not mission:
+        return await callback.answer("Misión no encontrada", show_alert=True)
+    await service.toggle_mission_status(mission_id, not mission.is_active)
+    status = "Activa" if not mission.is_active else "Inactiva"
+    await callback.answer(f"Misión ahora está {status}.", show_alert=True)
+    await show_missions_page(callback.message, session, 0)

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -603,17 +603,21 @@ def get_admin_mission_list_keyboard(missions: list, page: int, has_prev: bool, h
     rows: list[list[InlineKeyboardButton]] = []
     for m in missions:
         rows.append([
-            InlineKeyboardButton(text="✏️", callback_data=f"edit_mission:{m.id}"),
-            InlineKeyboardButton(text="🗑", callback_data=f"delete_mission:{m.id}"),
-            InlineKeyboardButton(text="✅" if m.is_active else "❌", callback_data=f"toggle_mission:{m.id}"),
+            InlineKeyboardButton(text="✏️", callback_data=f"mission_edit:{m.id}"),
+            InlineKeyboardButton(text="🗑", callback_data=f"mission_delete:{m.id}"),
+            InlineKeyboardButton(text="ℹ️", callback_data=f"mission_view_details:{m.id}"),
+            InlineKeyboardButton(text="✅" if m.is_active else "❌", callback_data=f"mission_toggle_active:{m.id}"),
         ])
+
     nav: list[InlineKeyboardButton] = []
     if has_prev:
         nav.append(InlineKeyboardButton(text="⬅️", callback_data=f"missions_page:{page-1}"))
+    nav.append(InlineKeyboardButton(text=f"{page+1}", callback_data="noop"))
     if has_next:
         nav.append(InlineKeyboardButton(text="➡️", callback_data=f"missions_page:{page+1}"))
     if nav:
         rows.append(nav)
-    rows.append([InlineKeyboardButton(text="➕ Crear Nueva", callback_data="admin_create_mission")])
-    rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="game_admin_main")])
+
+    rows.append([InlineKeyboardButton(text="➕ Crear Nueva Misión", callback_data="mission_create")])
+    rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_kinky_game")])
     return InlineKeyboardMarkup(inline_keyboard=rows)

--- a/mybot/utils/message_utils.py
+++ b/mybot/utils/message_utils.py
@@ -1,4 +1,6 @@
 # utils/message_utils.py
+from aiogram.types import Message, InlineKeyboardMarkup
+from aiogram.exceptions import TelegramBadRequest
 from database.models import User, Mission, Reward, UserAchievement
 from services.level_service import LevelService
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -7,6 +9,21 @@ from services.achievement_service import ACHIEVEMENTS
 from utils.messages import BOT_MESSAGES
 from utils.text_utils import anonymize_username
 import datetime
+
+
+async def safe_edit_message(
+    message: Message,
+    text: str,
+    reply_markup: InlineKeyboardMarkup | None = None,
+) -> None:
+    """Safely edit a message only if content or markup changed."""
+    if message.text == text and message.reply_markup == reply_markup:
+        return
+    try:
+        await message.edit_text(text, reply_markup=reply_markup)
+    except TelegramBadRequest as exc:
+        if "message is not modified" not in str(exc).lower():
+            raise
 
 
 async def get_profile_message(

--- a/mybot/utils/pagination.py
+++ b/mybot/utils/pagination.py
@@ -10,3 +10,15 @@ async def paginate(session: AsyncSession, stmt, page: int = 0, page_size: int = 
     has_prev = page > 0
     has_next = (page + 1) * page_size < total
     return items, total, has_prev, has_next
+
+
+async def get_paginated_list(session: AsyncSession, stmt, page: int = 0, page_size: int = 5):
+    """Return paginated items with navigation info."""
+    total_stmt = select(func.count()).select_from(stmt.subquery())
+    total = (await session.execute(total_stmt)).scalar_one()
+    result = await session.execute(stmt.offset(page * page_size).limit(page_size))
+    items = result.scalars().all()
+    total_pages = (total + page_size - 1) // page_size if total else 1
+    has_prev = page > 0
+    has_next = (page + 1) < total_pages
+    return items, has_prev, has_next, total_pages


### PR DESCRIPTION
## Summary
- update kinky game button to show main content keyboard
- add safe_edit_message helper
- support generic pagination helper
- redesign admin mission list keyboard
- reimplement missions admin with paginated listing and CRUD actions

## Testing
- `python -m py_compile mybot/utils/message_utils.py mybot/utils/pagination.py mybot/utils/keyboard_utils.py mybot/handlers/admin/admin_menu.py mybot/handlers/admin/missions_admin.py`

------
https://chatgpt.com/codex/tasks/task_e_685c6e933834832999f86263c2524e19