### PR TITLE
Fix missions admin UI

### DIFF
--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -30,6 +30,7 @@ from .config_menu import router as config_router
 from .channel_admin import router as channel_admin_router
 from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
+from .missions_admin import router as missions_admin_router
 from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
 
@@ -39,6 +40,7 @@ router.include_router(config_router)
 router.include_router(channel_admin_router)
 router.include_router(subscription_plans_router)
 router.include_router(game_admin_router)
+router.include_router(missions_admin_router)
 router.include_router(event_admin_router)
 router.include_router(admin_config_router)
 

--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -22,6 +22,7 @@ from utils.keyboard_utils import (
     get_badge_selection_keyboard,
     get_reward_type_keyboard,
 )
+from .missions_admin import show_missions_page
 from utils.admin_state import (
     AdminUserStates,
     AdminMissionStates,
@@ -205,13 +206,7 @@ async def process_search_user(message: Message, state: FSMContext, session: Asyn
 async def admin_content_missions(callback: CallbackQuery, session: AsyncSession):
     if not is_admin(callback.from_user.id):
         return await callback.answer()
-    await update_menu(
-        callback,
-        "📌 Misiones - Selecciona una opción:",
-        get_admin_content_missions_keyboard(),
-        session,
-        "admin_content_missions",
-    )
+    await show_missions_page(callback.message, session, 0)
     await callback.answer()
 
 


### PR DESCRIPTION
## Summary
- include `missions_admin` router so missions handlers register
- open mission list directly from Kinky Game menu
- tweak missions page text formatting and safe edit usage

## Testing
- `pytest -q` *(fails: BOT_TOKEN environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_685c73b1c9788329a3f084824d8225d4