### PR TITLE
Improve admin mission list layout

### DIFF
--- a/mybot/handlers/admin/missions_admin.py
+++ b/mybot/handlers/admin/missions_admin.py
@@ -18,15 +18,8 @@ router = Router()
 async def show_missions_page(message: Message, session: AsyncSession, page: int) -> None:
     stmt = select(Mission).order_by(Mission.created_at)
     missions, has_prev, has_next, total_pages = await get_paginated_list(session, stmt, page)
-    lines = [f"📌 Misiones (Página {page + 1} de {total_pages})"]
-    for m in missions:
-        mission_line = (
-            f"Misión ID: {str(m.id)[:8]} | Título: {m.name} | Tipo: {m.type} | "
-            f"Puntos: {m.reward_points} | Activa: {'Sí' if m.is_active else 'No'}"
-        )
-        lines.append(mission_line)
-        lines.append("---")
-    text = "\n".join(lines).strip()
+    # Solo mostrar el encabezado "📌 Misiones"
+    text = "📌 Misiones"
     kb = get_admin_mission_list_keyboard(missions, page, has_prev, has_next)
     await safe_edit_message(message, text, kb)
 

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -599,9 +599,12 @@ def get_game_admin_main_keyboard() -> InlineKeyboardMarkup:
 
 
 def get_admin_mission_list_keyboard(missions: list, page: int, has_prev: bool, has_next: bool) -> InlineKeyboardMarkup:
-    """Keyboard for a paginated list of missions."""
+    """Keyboard for a paginated list of missions displayed as rows."""
     rows: list[list[InlineKeyboardButton]] = []
     for m in missions:
+        # Fila con el nombre de la misión
+        rows.append([InlineKeyboardButton(text=m.name, callback_data="noop")])
+        # Fila con las acciones de la misión
         rows.append([
             InlineKeyboardButton(text="✏️", callback_data=f"mission_edit:{m.id}"),
             InlineKeyboardButton(text="🗑", callback_data=f"mission_delete:{m.id}"),


### PR DESCRIPTION
## Summary
- simplify missions header text
- show each mission name above its action buttons

## Testing
- `python -m py_compile mybot/handlers/admin/missions_admin.py mybot/utils/keyboard_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685c7e8485508329bbb8aeed2198e237