### PR TITLE
Implement basic paginated admin handlers

### DIFF
--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -6,6 +6,9 @@ from .channel_admin import router as channel_admin_router
 from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
 from .missions_admin import router as missions_admin_router
+from .levels_admin import router as levels_admin_router
+from .rewards_admin import router as rewards_admin_router
+from .badges_admin import router as badges_admin_router
 from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
 
@@ -18,6 +21,9 @@ __all__ = [
     "subscription_plans_router",
     "game_admin_router",
     "missions_admin_router",
+    "levels_admin_router",
+    "rewards_admin_router",
+    "badges_admin_router",
     "event_admin_router",
     "admin_config_router",
 ]

--- a/mybot/handlers/admin/badges_admin.py
+++ b/mybot/handlers/admin/badges_admin.py
@@ -1,0 +1,108 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from utils.user_roles import is_admin
+from utils.pagination import get_paginated_list
+from utils.keyboard_utils import get_admin_badge_list_keyboard, get_back_keyboard
+from utils.message_utils import safe_edit_message
+from services.badge_service import BadgeService
+from database.models import Badge
+
+router = Router()
+
+async def show_badges_page(message: Message, session: AsyncSession, page: int) -> None:
+    stmt = select(Badge).order_by(Badge.id)
+    badges, has_prev, has_next, _ = await get_paginated_list(session, stmt, page)
+    text = "🏅 Insignias"
+    kb = get_admin_badge_list_keyboard(badges, page, has_prev, has_next)
+    await safe_edit_message(message, text, kb)
+
+
+@router.callback_query(F.data == "admin_content_badges")
+async def list_badges(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await show_badges_page(callback.message, session, 0)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("badges_page:"))
+async def badges_page(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    page = int(callback.data.split(":")[1])
+    await show_badges_page(callback.message, session, page)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("badge_view_details:"))
+async def badge_view_details(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    badge_id = int(callback.data.split(":")[1])
+    badge = await session.get(Badge, badge_id)
+    if not badge:
+        return await callback.answer("Insignia no encontrada", show_alert=True)
+    lines = [
+        f"ID: {badge.id}",
+        f"Nombre: {badge.name}",
+        f"Criterio: {getattr(badge, 'requirement', '')}",
+        f"Activa: {'Sí' if badge.is_active else 'No'}",
+    ]
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Editar Insignia", callback_data=f"badge_edit:{badge.id}")],
+            [InlineKeyboardButton(text="Eliminar Insignia", callback_data=f"badge_delete:{badge.id}")],
+            [InlineKeyboardButton(text="Activar/Desactivar", callback_data=f"badge_toggle_active:{badge.id}")],
+            [InlineKeyboardButton(text="🔙 Volver a Insignias", callback_data="admin_content_badges")],
+        ]
+    )
+    await safe_edit_message(callback.message, "\n".join(lines), kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "badge_create")
+async def badge_create(callback: CallbackQuery, state: FSMContext):
+    from .game_admin import admin_create_badge
+    await admin_create_badge(callback, state)
+
+
+@router.callback_query(F.data.startswith("badge_edit:"))
+async def badge_edit(callback: CallbackQuery, session: AsyncSession, state: FSMContext):
+    from .game_admin import select_badge
+    badge_id = callback.data.split(":")[1]
+    callback.data = f"select_badge_{badge_id}"
+    await select_badge(callback, state, session)
+
+
+@router.callback_query(F.data.startswith("badge_delete:"))
+async def badge_delete(callback: CallbackQuery, session: AsyncSession, state: FSMContext):
+    from .game_admin import select_badge
+    badge_id = callback.data.split(":")[1]
+    callback.data = f"select_badge_{badge_id}"
+    await select_badge(callback, state, session)
+
+
+@router.callback_query(F.data == "confirm_delete_badge")
+async def badge_delete_confirm(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    from .game_admin import confirm_delete_badge
+    await confirm_delete_badge(callback, state, session)
+
+
+@router.callback_query(F.data.startswith("badge_toggle_active:"))
+async def badge_toggle_active(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    badge_id = int(callback.data.split(":")[1])
+    service = BadgeService(session)
+    badge = await session.get(Badge, badge_id)
+    if not badge:
+        return await callback.answer("Insignia no encontrada", show_alert=True)
+    await service.toggle_badge_status(badge_id, not badge.is_active)
+    status = "Activa" if not badge.is_active else "Inactiva"
+    await callback.answer(f"Insignia ahora está {status}", show_alert=True)
+    await show_badges_page(callback.message, session, 0)
+

--- a/mybot/handlers/admin/levels_admin.py
+++ b/mybot/handlers/admin/levels_admin.py
@@ -1,0 +1,96 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from utils.user_roles import is_admin
+from utils.pagination import get_paginated_list
+from utils.keyboard_utils import get_admin_level_list_keyboard, get_back_keyboard
+from utils.message_utils import safe_edit_message
+from services.level_service import LevelService
+from database.models import Level, LorePiece
+
+router = Router()
+
+async def show_levels_page(message: Message, session: AsyncSession, page: int) -> None:
+    stmt = select(Level).order_by(Level.level_id)
+    levels, has_prev, has_next, _ = await get_paginated_list(session, stmt, page)
+    text = "📈 Niveles"
+    kb = get_admin_level_list_keyboard(levels, page, has_prev, has_next)
+    await safe_edit_message(message, text, kb)
+
+
+@router.callback_query(F.data == "admin_content_levels")
+async def list_levels(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await show_levels_page(callback.message, session, 0)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("levels_page:"))
+async def levels_page(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    page = int(callback.data.split(":")[1])
+    await show_levels_page(callback.message, session, page)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("level_view_details:"))
+async def level_view_details(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    level_id = int(callback.data.split(":")[1])
+    level = await session.get(Level, level_id)
+    if not level:
+        return await callback.answer("Nivel no encontrado", show_alert=True)
+    lines = [
+        f"**Nivel {level.level_id} - {level.name}**",
+        f"Pts Mínimos: {level.min_points}",
+        f"Recompensa: {level.reward or '-'}",
+    ]
+    if level.unlocks_lore_piece_code:
+        stmt = select(LorePiece).where(LorePiece.code_name == level.unlocks_lore_piece_code)
+        lore = (await session.execute(stmt)).scalar_one_or_none()
+        if lore:
+            lines.append(f"Pista: {lore.title}")
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Editar Nivel", callback_data=f"level_edit:{level.level_id}")],
+            [InlineKeyboardButton(text="Eliminar Nivel", callback_data=f"level_delete:{level.level_id}")],
+            [InlineKeyboardButton(text="🔙 Volver a Niveles", callback_data="admin_content_levels")],
+        ]
+    )
+    await safe_edit_message(callback.message, "\n".join(lines), kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "level_create")
+async def level_create(callback: CallbackQuery, state: FSMContext):
+    from .game_admin import admin_level_add
+    await admin_level_add(callback, state)
+
+
+@router.callback_query(F.data.startswith("level_edit:"))
+async def level_edit(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    from .game_admin import start_edit_level
+    level_id = callback.data.split(":")[1]
+    callback.data = f"edit_level_{level_id}"
+    await start_edit_level(callback, state, session)
+
+
+@router.callback_query(F.data.startswith("level_delete:"))
+async def level_delete(callback: CallbackQuery, session: AsyncSession):
+    from .game_admin import confirm_del_level
+    level_id = callback.data.split(":")[1]
+    callback.data = f"del_level_{level_id}"
+    await confirm_del_level(callback, session)
+
+
+@router.callback_query(F.data.startswith("confirm_del_level_"))
+async def level_delete_confirm(callback: CallbackQuery, session: AsyncSession):
+    from .game_admin import delete_level
+    await delete_level(callback, session)
+

--- a/mybot/handlers/admin/rewards_admin.py
+++ b/mybot/handlers/admin/rewards_admin.py
@@ -1,0 +1,110 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from utils.user_roles import is_admin
+from utils.pagination import get_paginated_list
+from utils.keyboard_utils import get_admin_reward_list_keyboard, get_back_keyboard
+from utils.message_utils import safe_edit_message
+from services.reward_service import RewardService
+from database.models import Reward
+
+router = Router()
+
+async def show_rewards_page(message: Message, session: AsyncSession, page: int) -> None:
+    stmt = select(Reward).order_by(Reward.id)
+    rewards, has_prev, has_next, _ = await get_paginated_list(session, stmt, page)
+    text = "🎁 Recompensas"
+    kb = get_admin_reward_list_keyboard(rewards, page, has_prev, has_next)
+    await safe_edit_message(message, text, kb)
+
+
+@router.callback_query(F.data == "admin_content_rewards")
+async def list_rewards(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await show_rewards_page(callback.message, session, 0)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("rewards_page:"))
+async def rewards_page(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    page = int(callback.data.split(":")[1])
+    await show_rewards_page(callback.message, session, page)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("reward_view_details:"))
+async def reward_view_details(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    reward_id = int(callback.data.split(":")[1])
+    reward = await session.get(Reward, reward_id)
+    if not reward:
+        return await callback.answer("Recompensa no encontrada", show_alert=True)
+    lines = [
+        f"ID: {reward.id}",
+        f"Nombre: {reward.title}",
+        f"Tipo: {reward.reward_type or '-'}",
+        f"Valor: {reward.required_points}",
+        f"Descripción: {reward.description or '-'}",
+        f"Activa: {'Sí' if reward.is_active else 'No'}",
+    ]
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Editar Recompensa", callback_data=f"reward_edit:{reward.id}")],
+            [InlineKeyboardButton(text="Eliminar Recompensa", callback_data=f"reward_delete:{reward.id}")],
+            [InlineKeyboardButton(text="Activar/Desactivar", callback_data=f"reward_toggle_active:{reward.id}")],
+            [InlineKeyboardButton(text="🔙 Volver a Recompensas", callback_data="admin_content_rewards")],
+        ]
+    )
+    await safe_edit_message(callback.message, "\n".join(lines), kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "reward_create")
+async def reward_create(callback: CallbackQuery, state: FSMContext):
+    from .game_admin import admin_reward_add
+    await admin_reward_add(callback, state)
+
+
+@router.callback_query(F.data.startswith("reward_edit:"))
+async def reward_edit(callback: CallbackQuery, session: AsyncSession, state: FSMContext):
+    from .game_admin import start_edit_reward
+    reward_id = callback.data.split(":")[1]
+    callback.data = f"edit_reward_{reward_id}"
+    await start_edit_reward(callback, session, state)
+
+
+@router.callback_query(F.data.startswith("reward_delete:"))
+async def reward_delete(callback: CallbackQuery, session: AsyncSession):
+    from .game_admin import confirm_delete_reward
+    reward_id = callback.data.split(":")[1]
+    callback.data = f"del_reward_{reward_id}"
+    await confirm_delete_reward(callback, session)
+
+
+@router.callback_query(F.data.startswith("confirm_del_reward_"))
+async def reward_delete_confirm(callback: CallbackQuery, session: AsyncSession):
+    from .game_admin import delete_reward
+    await delete_reward(callback, session)
+
+
+@router.callback_query(F.data.startswith("reward_toggle_active:"))
+async def reward_toggle_active(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    reward_id = int(callback.data.split(":")[1])
+    service = RewardService(session)
+    reward = await service.get_reward_by_id(reward_id)
+    if not reward:
+        return await callback.answer("Recompensa no encontrada", show_alert=True)
+    await service.toggle_reward_status(reward_id, not reward.is_active)
+    status = "Activa" if not reward.is_active else "Inactiva"
+    await callback.answer(f"Recompensa ahora está {status}", show_alert=True)
+    await show_rewards_page(callback.message, session, 0)
+

--- a/mybot/services/badge_service.py
+++ b/mybot/services/badge_service.py
@@ -63,3 +63,34 @@ class BadgeService:
                 if bot:
                     text = f"🏅 Has obtenido la insignia {badge.emoji or ''} {badge.name}!"
                     await bot.send_message(user.id, text)
+
+    async def update_badge(
+        self,
+        badge_id: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        requirement: str | None = None,
+        emoji: str | None = None,
+    ) -> bool:
+        badge = await self.session.get(Badge, badge_id)
+        if not badge:
+            return False
+        if name is not None:
+            badge.name = name.strip()
+        if description is not None:
+            badge.description = description.strip()
+        if requirement is not None:
+            badge.requirement = requirement.strip()
+        if emoji is not None:
+            badge.emoji = emoji
+        await self.session.commit()
+        return True
+
+    async def toggle_badge_status(self, badge_id: int, status: bool) -> bool:
+        badge = await self.session.get(Badge, badge_id)
+        if badge:
+            badge.is_active = status
+            await self.session.commit()
+            return True
+        return False

--- a/mybot/states/gamification_states.py
+++ b/mybot/states/gamification_states.py
@@ -1,0 +1,34 @@
+from aiogram.fsm.state import StatesGroup, State
+
+class LevelAdminStates(StatesGroup):
+    creating_level_number = State()
+    creating_level_name = State()
+    creating_level_points = State()
+    creating_level_reward = State()
+    confirming_create_level = State()
+
+    editing_level_number = State()
+    editing_level_name = State()
+    editing_level_points = State()
+    editing_level_reward = State()
+
+    deleting_level = State()
+
+class RewardAdminStates(StatesGroup):
+    creating_reward_name = State()
+    creating_reward_points = State()
+    creating_reward_description = State()
+    creating_reward_type = State()
+
+    editing_reward_name = State()
+    editing_reward_points = State()
+    editing_reward_description = State()
+    editing_reward_type = State()
+
+class BadgeAdminStates(StatesGroup):
+    creating_badge_name = State()
+    creating_badge_description = State()
+    creating_badge_requirement = State()
+    creating_badge_emoji = State()
+
+    deleting_badge = State()

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -624,3 +624,73 @@ def get_admin_mission_list_keyboard(missions: list, page: int, has_prev: bool, h
     rows.append([InlineKeyboardButton(text="➕ Crear Nueva Misión", callback_data="mission_create")])
     rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_kinky_game")])
     return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def get_admin_level_list_keyboard(levels: list, page: int, has_prev: bool, has_next: bool) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    for lvl in levels:
+        rows.append([InlineKeyboardButton(text=f"{lvl.level_id}. {lvl.name}", callback_data="noop")])
+        rows.append([
+            InlineKeyboardButton(text="✏️", callback_data=f"level_edit:{lvl.level_id}"),
+            InlineKeyboardButton(text="🗑", callback_data=f"level_delete:{lvl.level_id}"),
+            InlineKeyboardButton(text="ℹ️", callback_data=f"level_view_details:{lvl.level_id}"),
+        ])
+    nav: list[InlineKeyboardButton] = []
+    if has_prev:
+        nav.append(InlineKeyboardButton(text="⬅️", callback_data=f"levels_page:{page-1}"))
+    nav.append(InlineKeyboardButton(text=f"{page+1}", callback_data="noop"))
+    if has_next:
+        nav.append(InlineKeyboardButton(text="➡️", callback_data=f"levels_page:{page+1}"))
+    if nav:
+        rows.append(nav)
+    rows.append([InlineKeyboardButton(text="➕ Crear Nuevo Nivel", callback_data="level_create")])
+    rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_kinky_game")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def get_admin_reward_list_keyboard(rewards: list, page: int, has_prev: bool, has_next: bool) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    for r in rewards:
+        status_icon = "✅" if r.is_active else "❌"
+        rows.append([InlineKeyboardButton(text=r.title, callback_data="noop")])
+        rows.append([
+            InlineKeyboardButton(text="✏️", callback_data=f"reward_edit:{r.id}"),
+            InlineKeyboardButton(text="🗑", callback_data=f"reward_delete:{r.id}"),
+            InlineKeyboardButton(text="ℹ️", callback_data=f"reward_view_details:{r.id}"),
+            InlineKeyboardButton(text=status_icon, callback_data=f"reward_toggle_active:{r.id}"),
+        ])
+    nav: list[InlineKeyboardButton] = []
+    if has_prev:
+        nav.append(InlineKeyboardButton(text="⬅️", callback_data=f"rewards_page:{page-1}"))
+    nav.append(InlineKeyboardButton(text=f"{page+1}", callback_data="noop"))
+    if has_next:
+        nav.append(InlineKeyboardButton(text="➡️", callback_data=f"rewards_page:{page+1}"))
+    if nav:
+        rows.append(nav)
+    rows.append([InlineKeyboardButton(text="➕ Crear Nueva Recompensa", callback_data="reward_create")])
+    rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_kinky_game")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def get_admin_badge_list_keyboard(badges: list, page: int, has_prev: bool, has_next: bool) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    for b in badges:
+        status_icon = "✅" if b.is_active else "❌"
+        rows.append([InlineKeyboardButton(text=b.name, callback_data="noop")])
+        rows.append([
+            InlineKeyboardButton(text="✏️", callback_data=f"badge_edit:{b.id}"),
+            InlineKeyboardButton(text="🗑", callback_data=f"badge_delete:{b.id}"),
+            InlineKeyboardButton(text="ℹ️", callback_data=f"badge_view_details:{b.id}"),
+            InlineKeyboardButton(text=status_icon, callback_data=f"badge_toggle_active:{b.id}"),
+        ])
+    nav: list[InlineKeyboardButton] = []
+    if has_prev:
+        nav.append(InlineKeyboardButton(text="⬅️", callback_data=f"badges_page:{page-1}"))
+    nav.append(InlineKeyboardButton(text=f"{page+1}", callback_data="noop"))
+    if has_next:
+        nav.append(InlineKeyboardButton(text="➡️", callback_data=f"badges_page:{page+1}"))
+    if nav:
+        rows.append(nav)
+    rows.append([InlineKeyboardButton(text="➕ Crear Nueva Insignia", callback_data="badge_create")])
+    rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_kinky_game")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)


### PR DESCRIPTION
## Summary
- add FSM state groups for gamification features
- extend keyboard utilities with paginated keyboards for levels, rewards and badges
- implement admin handlers for levels, rewards and badges following the missions pattern
- expose new routers in the admin package
- extend badge service with update/toggle methods

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_685c866cf21883299eb963a68e032b46