### PR TITLE
Add LorePieces admin management

### DIFF
--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -9,6 +9,7 @@ from .missions_admin import router as missions_admin_router
 from .levels_admin import router as levels_admin_router
 from .rewards_admin import router as rewards_admin_router
 from .badges_admin import router as badges_admin_router
+from .lore_pieces_admin import router as lore_pieces_admin_router
 from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
 
@@ -24,6 +25,7 @@ __all__ = [
     "levels_admin_router",
     "rewards_admin_router",
     "badges_admin_router",
+    "lore_pieces_admin_router",
     "event_admin_router",
     "admin_config_router",
 ]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -32,6 +32,7 @@ from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
 from .missions_admin import router as missions_admin_router
 from .levels_admin import router as levels_admin_router
+from .lore_pieces_admin import router as lore_pieces_admin_router
 from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
 
@@ -43,6 +44,7 @@ router.include_router(subscription_plans_router)
 router.include_router(game_admin_router)
 router.include_router(missions_admin_router)
 router.include_router(levels_admin_router)
+router.include_router(lore_pieces_admin_router)
 router.include_router(event_admin_router)
 router.include_router(admin_config_router)
 

--- a/mybot/handlers/admin/lore_pieces_admin.py
+++ b/mybot/handlers/admin/lore_pieces_admin.py
@@ -1,0 +1,400 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from utils.user_roles import is_admin
+from utils.pagination import get_paginated_list
+from utils.keyboard_utils import get_admin_lore_piece_list_keyboard, get_back_keyboard
+from utils.message_utils import safe_edit_message
+from states.gamification_states import LorePieceAdminStates
+from services.lore_piece_service import LorePieceService
+from database.models import LorePiece
+
+router = Router()
+
+async def show_lore_pieces_page(message: Message, session: AsyncSession, page: int) -> None:
+    stmt = select(LorePiece).order_by(LorePiece.id)
+    pieces, has_prev, has_next, _ = await get_paginated_list(session, stmt, page)
+    lines = [
+        "🧩 Pistas",
+    ]
+    for p in pieces:
+        lines.append(
+            f"Pista ID: {p.code_name} | Título: {p.title} | Tipo: {p.content_type} | Categoría: {p.category or '-'} | Historia Principal: {'Sí' if p.is_main_story else 'No'}"
+        )
+    kb = get_admin_lore_piece_list_keyboard(pieces, page, has_prev, has_next)
+    await safe_edit_message(message, "\n".join(lines), kb)
+
+
+@router.callback_query(F.data.in_({"admin_manage_lorepieces", "admin_content_lore_pieces"}))
+async def list_lore_pieces(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await show_lore_pieces_page(callback.message, session, 0)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("lore_piece_page:"))
+async def lore_pieces_page(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    page = int(callback.data.split(":")[1])
+    await show_lore_pieces_page(callback.message, session, page)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("lore_piece_view_details:"))
+async def lore_piece_view_details(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    code = callback.data.split(":")[1]
+    piece = await LorePieceService(session).get_lore_piece_by_code(code)
+    if not piece:
+        return await callback.answer("Pista no encontrada", show_alert=True)
+    lines = [
+        f"Código: {piece.code_name}",
+        f"Título: {piece.title}",
+        f"Descripción: {piece.description or '-'}",
+        f"Tipo: {piece.content_type}",
+        f"Categoría: {piece.category or '-'}",
+        f"Historia Principal: {'Sí' if piece.is_main_story else 'No'}",
+    ]
+    if piece.content_type == "text":
+        lines.append(f"Contenido: {piece.content}")
+    else:
+        lines.append("Contenido: [Ver archivo adjunto]")
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Editar Pista", callback_data=f"lore_piece_edit:{piece.code_name}")],
+            [InlineKeyboardButton(text="Eliminar Pista", callback_data=f"lore_piece_delete:{piece.code_name}")],
+            [InlineKeyboardButton(text="🔙 Volver a Pistas", callback_data="admin_manage_lorepieces")],
+        ]
+    )
+    await safe_edit_message(callback.message, "\n".join(lines), kb)
+    if piece.content_type in {"image", "video", "audio"}:
+        try:
+            if piece.content_type == "image":
+                await callback.message.answer_photo(piece.content)
+            elif piece.content_type == "video":
+                await callback.message.answer_video(piece.content)
+            elif piece.content_type == "audio":
+                await callback.message.answer_audio(piece.content)
+        except Exception:
+            pass
+    await callback.answer()
+
+
+@router.callback_query(F.data == "lore_piece_create")
+async def lore_piece_create(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Ingresa el code_name único para la pista:",
+        reply_markup=get_back_keyboard("admin_manage_lorepieces"),
+    )
+    await state.set_state(LorePieceAdminStates.creating_code_name)
+    await callback.answer()
+
+
+@router.message(LorePieceAdminStates.creating_code_name)
+async def lore_piece_process_code(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    code = message.text.strip()
+    exists = await LorePieceService(session).get_lore_piece_by_code(code)
+    if exists:
+        await message.answer("Ese code_name ya existe, ingresa uno diferente:")
+        return
+    await state.update_data(code_name=code)
+    await message.answer("Título de la pista:")
+    await state.set_state(LorePieceAdminStates.creating_title)
+
+
+@router.message(LorePieceAdminStates.creating_title)
+async def lore_piece_process_title(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(title=message.text.strip())
+    await message.answer("Descripción de la pista:")
+    await state.set_state(LorePieceAdminStates.creating_description)
+
+
+@router.message(LorePieceAdminStates.creating_description)
+async def lore_piece_process_description(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(description=message.text.strip())
+    await message.answer("Categoría de la pista (opcional):")
+    await state.set_state(LorePieceAdminStates.creating_category)
+
+
+@router.message(LorePieceAdminStates.creating_category)
+async def lore_piece_process_category(message: Message, state: FSMContext):
+    if not is_admin(message.from_user.id):
+        return
+    await state.update_data(category=message.text.strip())
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Sí", callback_data="lore_piece_main_story:yes"),
+             InlineKeyboardButton(text="No", callback_data="lore_piece_main_story:no")],
+        ]
+    )
+    await message.answer("¿Pertenece a la historia principal?", reply_markup=kb)
+    await state.set_state(LorePieceAdminStates.creating_is_main_story)
+
+
+@router.callback_query(LorePieceAdminStates.creating_is_main_story, F.data.startswith("lore_piece_main_story:"))
+async def lore_piece_process_main_story(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    choice = callback.data.split(":")[1]
+    await state.update_data(is_main_story=choice == "yes")
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Texto", callback_data="lore_piece_content_type:text")],
+            [InlineKeyboardButton(text="Imagen", callback_data="lore_piece_content_type:image")],
+            [InlineKeyboardButton(text="Audio", callback_data="lore_piece_content_type:audio")],
+            [InlineKeyboardButton(text="Video", callback_data="lore_piece_content_type:video")],
+        ]
+    )
+    await callback.message.edit_text(
+        "Selecciona el tipo de contenido:", reply_markup=kb
+    )
+    await state.set_state(LorePieceAdminStates.creating_content_type)
+    await callback.answer()
+
+
+@router.callback_query(LorePieceAdminStates.creating_content_type, F.data.startswith("lore_piece_content_type:"))
+async def lore_piece_select_type(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    ctype = callback.data.split(":")[1]
+    await state.update_data(content_type=ctype)
+    await callback.message.edit_text(
+        "Envía el contenido ahora:",
+        reply_markup=get_back_keyboard("admin_manage_lorepieces"),
+    )
+    await state.set_state(LorePieceAdminStates.creating_content)
+    await callback.answer()
+
+
+@router.message(LorePieceAdminStates.creating_content)
+async def lore_piece_receive_content(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    ctype = data.get("content_type")
+    content = None
+    if ctype == "text" and message.text:
+        content = message.text
+    elif ctype == "image" and message.photo:
+        content = message.photo[-1].file_id
+    elif ctype == "video" and message.video:
+        content = message.video.file_id
+    elif ctype == "audio" and message.audio:
+        content = message.audio.file_id
+    if not content:
+        await message.answer("Envía un contenido válido acorde al tipo seleccionado")
+        return
+    service = LorePieceService(session)
+    try:
+        await service.create_lore_piece(
+            data["code_name"],
+            data["title"],
+            data.get("description", ""),
+            ctype,
+            content,
+            category=data.get("category"),
+            is_main_story=data.get("is_main_story", False),
+        )
+        await message.answer("✅ Pista creada correctamente")
+    except IntegrityError:
+        await message.answer("Error: code_name duplicado")
+    await state.clear()
+    await show_lore_pieces_page(message, session, 0)
+
+
+@router.callback_query(F.data.startswith("lore_piece_edit:"))
+async def lore_piece_edit(callback: CallbackQuery):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    code = callback.data.split(":")[1]
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Título", callback_data=f"lore_piece_edit_field:title:{code}")],
+            [InlineKeyboardButton(text="Descripción", callback_data=f"lore_piece_edit_field:description:{code}")],
+            [InlineKeyboardButton(text="Categoría", callback_data=f"lore_piece_edit_field:category:{code}")],
+            [InlineKeyboardButton(text="Historia Principal", callback_data=f"lore_piece_edit_field:is_main_story:{code}")],
+            [InlineKeyboardButton(text="Tipo de Contenido", callback_data=f"lore_piece_edit_field:content_type:{code}")],
+            [InlineKeyboardButton(text="Contenido", callback_data=f"lore_piece_edit_field:content:{code}")],
+            [InlineKeyboardButton(text="🔙 Volver", callback_data=f"lore_piece_view_details:{code}")],
+        ]
+    )
+    await safe_edit_message(callback.message, "¿Qué campo deseas editar?", kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("lore_piece_edit_field:"))
+async def lore_piece_edit_field(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    _, field, code = callback.data.split(":")
+    await state.update_data(code=code)
+    prompts = {
+        "title": "Nuevo título:",
+        "description": "Nueva descripción:",
+        "category": "Nueva categoría:",
+    }
+    if field in {"title", "description", "category"}:
+        await callback.message.edit_text(prompts[field], reply_markup=get_back_keyboard(f"lore_piece_edit:{code}"))
+        mapping = {
+            "title": LorePieceAdminStates.editing_title,
+            "description": LorePieceAdminStates.editing_description,
+            "category": LorePieceAdminStates.editing_category,
+        }
+        await state.set_state(mapping[field])
+    elif field == "is_main_story":
+        kb = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text="Sí", callback_data="lore_piece_edit_main_story:yes"),
+                 InlineKeyboardButton(text="No", callback_data="lore_piece_edit_main_story:no")],
+            ]
+        )
+        await callback.message.edit_text("¿Pertenece a la historia principal?", reply_markup=kb)
+        await state.set_state(LorePieceAdminStates.editing_is_main_story)
+    elif field == "content_type":
+        kb = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text="Texto", callback_data="lore_piece_edit_type:text")],
+                [InlineKeyboardButton(text="Imagen", callback_data="lore_piece_edit_type:image")],
+                [InlineKeyboardButton(text="Audio", callback_data="lore_piece_edit_type:audio")],
+                [InlineKeyboardButton(text="Video", callback_data="lore_piece_edit_type:video")],
+            ]
+        )
+        await callback.message.edit_text("Selecciona el nuevo tipo de contenido:", reply_markup=kb)
+        await state.set_state(LorePieceAdminStates.editing_content_type)
+    elif field == "content":
+        await callback.message.edit_text("Envía el nuevo contenido:", reply_markup=get_back_keyboard(f"lore_piece_edit:{code}"))
+        await state.set_state(LorePieceAdminStates.editing_content)
+    await callback.answer()
+
+
+@router.message(LorePieceAdminStates.editing_title)
+async def process_edit_title(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    code = data.get("code")
+    await LorePieceService(session).update_lore_piece(code, title=message.text.strip())
+    await message.answer("Pista actualizada")
+    await state.clear()
+    await show_lore_pieces_page(message, session, 0)
+
+
+@router.message(LorePieceAdminStates.editing_description)
+async def process_edit_description(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    code = data.get("code")
+    await LorePieceService(session).update_lore_piece(code, description=message.text.strip())
+    await message.answer("Pista actualizada")
+    await state.clear()
+    await show_lore_pieces_page(message, session, 0)
+
+
+@router.message(LorePieceAdminStates.editing_category)
+async def process_edit_category(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    code = data.get("code")
+    await LorePieceService(session).update_lore_piece(code, category=message.text.strip())
+    await message.answer("Pista actualizada")
+    await state.clear()
+    await show_lore_pieces_page(message, session, 0)
+
+
+@router.callback_query(LorePieceAdminStates.editing_is_main_story, F.data.startswith("lore_piece_edit_main_story:"))
+async def process_edit_main_story(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    choice = callback.data.split(":")[1]
+    data = await state.get_data()
+    code = data.get("code")
+    await LorePieceService(session).update_lore_piece(code, is_main_story=choice == "yes")
+    await callback.answer("Pista actualizada", show_alert=True)
+    await state.clear()
+    await show_lore_pieces_page(callback.message, session, 0)
+
+
+@router.callback_query(LorePieceAdminStates.editing_content_type, F.data.startswith("lore_piece_edit_type:"))
+async def process_edit_content_type(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    ctype = callback.data.split(":")[1]
+    data = await state.get_data()
+    code = data.get("code")
+    await LorePieceService(session).update_lore_piece(code, content_type=ctype)
+    await callback.answer("Tipo actualizado", show_alert=True)
+    await state.clear()
+    await show_lore_pieces_page(callback.message, session, 0)
+
+
+@router.message(LorePieceAdminStates.editing_content)
+async def process_edit_content(message: Message, state: FSMContext, session: AsyncSession):
+    if not is_admin(message.from_user.id):
+        return
+    data = await state.get_data()
+    code = data.get("code")
+    piece = await LorePieceService(session).get_lore_piece_by_code(code)
+    if not piece:
+        await message.answer("Pista no encontrada")
+        await state.clear()
+        return
+    ctype = piece.content_type
+    content = None
+    if ctype == "text" and message.text:
+        content = message.text
+    elif ctype == "image" and message.photo:
+        content = message.photo[-1].file_id
+    elif ctype == "video" and message.video:
+        content = message.video.file_id
+    elif ctype == "audio" and message.audio:
+        content = message.audio.file_id
+    if not content:
+        await message.answer("Envía un contenido válido acorde al tipo actual")
+        return
+    await LorePieceService(session).update_lore_piece(code, content=content)
+    await message.answer("Pista actualizada")
+    await state.clear()
+    await show_lore_pieces_page(message, session, 0)
+
+
+@router.callback_query(F.data.startswith("lore_piece_delete:"))
+async def lore_piece_delete(callback: CallbackQuery):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    code = callback.data.split(":")[1]
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Sí, Eliminar", callback_data=f"lore_piece_delete_confirm:{code}")],
+            [InlineKeyboardButton(text="Cancelar", callback_data=f"lore_piece_view_details:{code}")],
+        ]
+    )
+    await safe_edit_message(callback.message, f"¿Eliminar permanentemente '{code}'?", kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("lore_piece_delete_confirm:"))
+async def lore_piece_delete_confirm(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    code = callback.data.split(":")[1]
+    await LorePieceService(session).delete_lore_piece(code)
+    await callback.answer("Pista eliminada", show_alert=True)
+    await show_lore_pieces_page(callback.message, session, 0)
+*** End Patch

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -13,6 +13,7 @@ from .event_service import EventService
 from .raffle_service import RaffleService
 from .message_service import MessageService
 from .auction_service import AuctionService
+from .lore_piece_service import LorePieceService
 from .user_service import UserService
 from .scheduler import channel_request_scheduler, vip_subscription_scheduler, vip_membership_scheduler
 
@@ -37,5 +38,6 @@ __all__ = [
     "RaffleService",
     "MessageService",
     "AuctionService",
+    "LorePieceService",
     "UserService",
 ]

--- a/mybot/services/lore_piece_service.py
+++ b/mybot/services/lore_piece_service.py
@@ -1,0 +1,73 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from database.models import LorePiece
+from utils.text_utils import sanitize_text
+import logging
+
+logger = logging.getLogger(__name__)
+
+class LorePieceService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def list_lore_pieces(self):
+        result = await self.session.execute(select(LorePiece).order_by(LorePiece.id))
+        return result.scalars().all()
+
+    async def get_lore_piece_by_code(self, code_name: str) -> LorePiece | None:
+        stmt = select(LorePiece).where(LorePiece.code_name == code_name)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create_lore_piece(
+        self,
+        code_name: str,
+        title: str,
+        description: str,
+        content_type: str,
+        content: str,
+        category: str | None = None,
+        is_main_story: bool = False,
+    ) -> LorePiece:
+        new_piece = LorePiece(
+            code_name=sanitize_text(code_name),
+            title=sanitize_text(title),
+            description=sanitize_text(description),
+            content_type=content_type,
+            content=content,
+            category=sanitize_text(category) if category else None,
+            is_main_story=is_main_story,
+        )
+        self.session.add(new_piece)
+        try:
+            await self.session.commit()
+        except IntegrityError:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(new_piece)
+        return new_piece
+
+    async def update_lore_piece(self, code_name: str, **fields) -> LorePiece | None:
+        piece = await self.get_lore_piece_by_code(code_name)
+        if not piece:
+            return None
+        for key, value in fields.items():
+            if value is None:
+                continue
+            if hasattr(piece, key):
+                if isinstance(value, str) and key in {"code_name", "title", "description", "category"}:
+                    setattr(piece, key, sanitize_text(value))
+                else:
+                    setattr(piece, key, value)
+        await self.session.commit()
+        await self.session.refresh(piece)
+        return piece
+
+    async def delete_lore_piece(self, code_name: str) -> bool:
+        piece = await self.get_lore_piece_by_code(code_name)
+        if not piece:
+            return False
+        await self.session.delete(piece)
+        await self.session.commit()
+        return True

--- a/mybot/states/gamification_states.py
+++ b/mybot/states/gamification_states.py
@@ -32,3 +32,20 @@ class BadgeAdminStates(StatesGroup):
     creating_badge_emoji = State()
 
     deleting_badge = State()
+
+
+class LorePieceAdminStates(StatesGroup):
+    creating_code_name = State()
+    creating_title = State()
+    creating_description = State()
+    creating_category = State()
+    creating_is_main_story = State()
+    creating_content_type = State()
+    creating_content = State()
+
+    editing_title = State()
+    editing_description = State()
+    editing_category = State()
+    editing_is_main_story = State()
+    editing_content_type = State()
+    editing_content = State()

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -694,3 +694,27 @@ def get_admin_badge_list_keyboard(badges: list, page: int, has_prev: bool, has_n
     rows.append([InlineKeyboardButton(text="➕ Crear Nueva Insignia", callback_data="badge_create")])
     rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_kinky_game")])
     return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def get_admin_lore_piece_list_keyboard(pieces: list, page: int, has_prev: bool, has_next: bool) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    for p in pieces:
+        rows.append([InlineKeyboardButton(text=f"{p.code_name} | {p.title}", callback_data="noop")])
+        rows.append([
+            InlineKeyboardButton(text="✏️", callback_data=f"lore_piece_edit:{p.code_name}"),
+            InlineKeyboardButton(text="🗑", callback_data=f"lore_piece_delete:{p.code_name}"),
+            InlineKeyboardButton(text="ℹ️", callback_data=f"lore_piece_view_details:{p.code_name}"),
+        ])
+
+    nav: list[InlineKeyboardButton] = []
+    if has_prev:
+        nav.append(InlineKeyboardButton(text="⬅️", callback_data=f"lore_piece_page:{page-1}"))
+    nav.append(InlineKeyboardButton(text=f"{page+1}", callback_data="noop"))
+    if has_next:
+        nav.append(InlineKeyboardButton(text="➡️", callback_data=f"lore_piece_page:{page+1}"))
+    if nav:
+        rows.append(nav)
+
+    rows.append([InlineKeyboardButton(text="➕ Crear Nueva Pista", callback_data="lore_piece_create")])
+    rows.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_kinky_game")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)


### PR DESCRIPTION
## Summary
- implement LorePieceService with CRUD operations
- support admin FSM states for LorePieces
- add inline keyboard helper for paginated lore pieces
- implement handlers for listing, creating, editing and deleting lore pieces
- register lore piece admin router

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c8efa51d483298ae9b8a69cbb0a35