### PR TITLE
Fix syntax error in lore_pieces_admin

### DIFF
--- a/mybot/handlers/admin/lore_pieces_admin.py
+++ b/mybot/handlers/admin/lore_pieces_admin.py
@@ -397,4 +397,3 @@ async def lore_piece_delete_confirm(callback: CallbackQuery, session: AsyncSessi
     await LorePieceService(session).delete_lore_piece(code)
     await callback.answer("Pista eliminada", show_alert=True)
     await show_lore_pieces_page(callback.message, session, 0)
-*** End Patch


### PR DESCRIPTION
## Summary
- remove leftover text from `lore_pieces_admin.py`

## Testing
- `python -m compileall -q mybot`

------
https://chatgpt.com/codex/tasks/task_e_685c931553548329909c2579a380a97e