### PR TITLE
Add Lore Pieces button to admin menu

### DIFF
--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -209,6 +209,11 @@ def get_admin_manage_content_keyboard():
             ],
             [
                 InlineKeyboardButton(
+                    text="📜 Pistas (Lore)", callback_data="admin_content_lore_pieces"
+                )
+            ],
+            [
+                InlineKeyboardButton(
                     text="🎁 Recompensas (Catálogo VIP)",
                     callback_data="admin_content_rewards",
                 )


### PR DESCRIPTION
## Summary
- add missing Lore Pieces option in admin content management keyboard

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9c850288832983efd6fa28f0c5ab