### PR TITLE
Fix missing level creation text

### DIFF
--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -174,12 +174,23 @@ MISSION_MESSAGES = {
     "view_all_missions_button_text": "📋 Ver Todas las Misiones",
 }
 
+# Administrative messages used in management panels
+ADMIN_MESSAGES = {
+    "level_created": "🎉 ¡Nivel creado exitosamente! 🎉",
+    "level_updated": "✅ Nivel actualizado correctamente.",
+    "level_deleted": "🗑️ Nivel eliminado exitosamente.",
+    "reward_created": "🎉 ¡Recompensa creada correctamente!",
+    "reward_updated": "✅ Recompensa actualizada correctamente.",
+    "reward_deleted": "🗑️ Recompensa eliminada correctamente.",
+}
+
 # Aggregate all messages for backward compatibility
 BOT_MESSAGES = {
     **BUTLER_MESSAGES,
     **KINKY_MESSAGES,
     **MENU_TEXTS,
     **MISSION_MESSAGES,
+    **ADMIN_MESSAGES,
 }
 
 # Badge descriptions


### PR DESCRIPTION
## Summary
- add admin messages for level and reward management
- include them in BOT_MESSAGES so admins see confirmations when levels are created

## Testing
- `pip install -r requirements.txt`
- `BOT_TOKEN=fake pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5061524883299e9e5a45ac61193a