### PR TITLE
Add Kinky game models

### DIFF
--- a/mybot/models/__init__.py
+++ b/mybot/models/__init__.py
@@ -1,0 +1,4 @@
+from .mission import Mission
+from .pista import Pista
+from .backpack_item import BackpackItem
+

--- a/mybot/models/backpack_item.py
+++ b/mybot/models/backpack_item.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from sqlalchemy import Integer, BigInteger, ForeignKey, DateTime
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.ext.asyncio import AsyncAttrs
+import datetime
+
+from database.models import Base, User
+from .pista import Pista
+
+
+class BackpackItem(AsyncAttrs, Base):
+    """Mapping of items owned by a user."""
+
+    __tablename__ = "backpack_items"
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey(User.id), primary_key=True)
+    pista_id: Mapped[int] = mapped_column(Integer, ForeignKey(Pista.id), primary_key=True)
+    quantity: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+    obtained_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, default=datetime.datetime.utcnow, nullable=False
+    )
+
+    # ORM relationships
+    user: Mapped[User] = relationship(User, backref="backpack_items")
+    pista: Mapped[Pista] = relationship(Pista, backref="owned_by")
+
+

--- a/mybot/models/mission.py
+++ b/mybot/models/mission.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from sqlalchemy import String, Text, Integer, DateTime, Boolean
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.ext.asyncio import AsyncAttrs
+import datetime
+
+from database.models import Base
+
+
+class Mission(AsyncAttrs, Base):
+    """Model for game missions."""
+
+    __tablename__ = "missions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    channel_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    mission_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    reward_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    reward_amount: Mapped[float] = mapped_column(Integer, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, default=datetime.datetime.utcnow
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+    )
+
+

--- a/mybot/models/pista.py
+++ b/mybot/models/pista.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from sqlalchemy import String, Text, Integer, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.ext.asyncio import AsyncAttrs
+import datetime
+
+from database.models import Base
+
+
+class Pista(AsyncAttrs, Base):
+    """Collectible hints/items that users can obtain."""
+
+    __tablename__ = "pistas"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    item_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    content_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, default=datetime.datetime.utcnow
+    )
+
+

--- a/scripts/kinky_models.sql
+++ b/scripts/kinky_models.sql
@@ -1,0 +1,34 @@
+-- SQL commands to create tables for the Kinky game models
+
+CREATE TABLE IF NOT EXISTS missions (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) UNIQUE NOT NULL,
+    description TEXT NOT NULL,
+    channel_type VARCHAR(50) NOT NULL,
+    mission_type VARCHAR(50) NOT NULL,
+    reward_type VARCHAR(50) NOT NULL,
+    reward_amount INTEGER NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    metadata JSONB,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS pistas (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(255) UNIQUE NOT NULL,
+    description TEXT,
+    item_type VARCHAR(50) NOT NULL,
+    content_text TEXT,
+    content_url VARCHAR,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS backpack_items (
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    pista_id INTEGER NOT NULL REFERENCES pistas(id),
+    quantity INTEGER NOT NULL DEFAULT 1,
+    obtained_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, pista_id)
+);
+


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for missions, pistas, and backpack inventory
- expose these models via `mybot.models`
- provide SQL script to create the corresponding tables

## Testing
- `python -m py_compile mybot/models/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5ac3e230832993e0df3da0091549