### PR TITLE
Fix reserved attribute error in Mission model

### DIFF
--- a/mybot/models/mission.py
+++ b/mybot/models/mission.py
@@ -22,7 +22,7 @@ class Mission(AsyncAttrs, Base):
     reward_type: Mapped[str] = mapped_column(String(50), nullable=False)
     reward_amount: Mapped[float] = mapped_column(Integer, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
-    metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    mission_data: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime, default=datetime.datetime.utcnow
     )

--- a/scripts/kinky_models.sql
+++ b/scripts/kinky_models.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS missions (
     reward_type VARCHAR(50) NOT NULL,
     reward_amount INTEGER NOT NULL,
     is_active BOOLEAN NOT NULL DEFAULT TRUE,
-    metadata JSONB,
+    mission_data JSONB,
     created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
- rename Mission.metadata column to mission_data
- update the SQL setup script accordingly
- try to rename the column in SQLite

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `sqlite3 gamification.db "ALTER TABLE missions RENAME COLUMN metadata TO mission_data;"` *(fails: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_685d635fa0c48329b21382f38fa2dd3f