### PR TITLE
Fix metadata table redefinition errors

### DIFF
--- a/mybot/models/backpack_item.py
+++ b/mybot/models/backpack_item.py
@@ -13,6 +13,7 @@ class BackpackItem(AsyncAttrs, Base):
     """Mapping of items owned by a user."""
 
     __tablename__ = "backpack_items"
+    __table_args__ = {"extend_existing": True}
     user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey(User.id), primary_key=True)
     pista_id: Mapped[int] = mapped_column(Integer, ForeignKey(Pista.id), primary_key=True)
     quantity: Mapped[int] = mapped_column(Integer, default=1, nullable=False)

--- a/mybot/models/mission.py
+++ b/mybot/models/mission.py
@@ -13,6 +13,7 @@ class Mission(AsyncAttrs, Base):
     """Model for game missions."""
 
     __tablename__ = "missions"
+    __table_args__ = {"extend_existing": True}
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)

--- a/mybot/models/pista.py
+++ b/mybot/models/pista.py
@@ -12,6 +12,7 @@ class Pista(AsyncAttrs, Base):
     """Collectible hints/items that users can obtain."""
 
     __tablename__ = "pistas"
+    __table_args__ = {"extend_existing": True}
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     title: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)


### PR DESCRIPTION
## Summary
- allow redefining metadata models by adding `extend_existing=True` to new models

## Testing
- `python -m compileall -q mybot/models/mission.py mybot/models/backpack_item.py mybot/models/pista.py`


------
https://chatgpt.com/codex/tasks/task_e_685d678f3274832982a4d0fbca16d7fa