### PR TITLE
Fix mission_id type in UserMissionEntry

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -123,7 +123,8 @@ class UserMissionEntry(AsyncAttrs, Base):
     __tablename__ = "user_mission_entries"
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(BigInteger, ForeignKey("users.id"))
-    mission_id = Column(String, ForeignKey("missions.id"))
+    # Use Integer to match the primary key type of the missions table
+    mission_id = Column(Integer, ForeignKey("missions.id"))
     progress_value = Column(Integer, default=0, nullable=False)
     completed = Column(Boolean, default=False)
     completed_at = Column(DateTime, nullable=True)


### PR DESCRIPTION
## Summary
- align `mission_id` field with Mission primary key

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d6bbe45488329be0dfc619200751e