### PR TITLE
Fix mission auto ID generation

### DIFF
--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -35,7 +35,8 @@ from utils.admin_state import (
 from services.mission_service import MissionService
 from services.reward_service import RewardService
 from services.level_service import LevelService
-from database.models import User, Mission, Level
+from database.models import User, Level
+from mybot.models import Mission
 from services.point_service import PointService
 from services.config_service import ConfigService
 from services.badge_service import BadgeService
@@ -318,12 +319,12 @@ async def admin_process_duration(message: Message, state: FSMContext, session: A
     data = await state.get_data()
     mission_service = MissionService(session)
     await mission_service.create_mission(
-        data["name"],
-        data["description"],
-        data["type"],
-        data["target"],
-        data["reward"],
-        days,
+        name=data["name"],
+        description=data["description"],
+        mission_type=data["type"],
+        target_value=data["target"],
+        reward_points=data["reward"],
+        duration_days=days,
     )
     await message.answer(
         "✅ Misión creada correctamente", reply_markup=get_admin_content_missions_keyboard()

--- a/mybot/handlers/admin/missions_admin.py
+++ b/mybot/handlers/admin/missions_admin.py
@@ -10,7 +10,8 @@ from utils.keyboard_utils import get_admin_mission_list_keyboard, get_back_keybo
 from utils.admin_state import AdminMissionStates, MissionAdminStates
 from utils.message_utils import safe_edit_message
 from services.mission_service import MissionService
-from database.models import Mission, LorePiece
+from mybot.models import Mission
+from database.models import LorePiece
 
 router = Router()
 
@@ -70,7 +71,7 @@ async def mission_view_details(callback: CallbackQuery, session: AsyncSession):
         "🔹 **Descripción:**",
         f"💬 {mission.description or '-'}",
         "",
-        f"🔸 **Tipo de Misión:** `{mission.type}`",
+        f"🔸 **Tipo de Misión:** `{mission.mission_type}`",
         f"🔸 **Puntos que Ganas:** {points_text}",
         f"🔸 **Estado:** {status_text}",
     ]

--- a/mybot/services/minigame_service.py
+++ b/mybot/services/minigame_service.py
@@ -1,7 +1,8 @@
 import datetime
 from aiogram import Bot
 from sqlalchemy.ext.asyncio import AsyncSession
-from database.models import UserStats, MiniGamePlay, Mission, UserMissionEntry
+from database.models import UserStats, MiniGamePlay, UserMissionEntry
+from mybot.models import Mission
 from .point_service import PointService
 from .mission_service import MissionService
 
@@ -42,11 +43,11 @@ class MiniGameService:
         mission_name = f"Reaction Challenge {user_id}"
         description = f"Reacciona {reactions} veces en {duration_minutes} minutos"
         mission = await ms.create_mission(
-            mission_name,
-            description,
-            "reaction_challenge",
-            reactions,
-            reward,
+            name=mission_name,
+            description=description,
+            mission_type="reaction_challenge",
+            target_value=reactions,
+            reward_points=reward,
             duration_days=0,
             requires_action=False,
             action_data={"duration_minutes": duration_minutes, "penalty_points": penalty},

--- a/mybot/services/tenant_service.py
+++ b/mybot/services/tenant_service.py
@@ -211,12 +211,12 @@ class TenantService:
             created_missions = []
             for mission_data in default_missions:
                 mission = await mission_service.create_mission(
-                    mission_data["name"],
-                    mission_data["description"],
-                    mission_data["mission_type"],
-                    mission_data["target_value"],
-                    mission_data["reward_points"],
-                    mission_data["duration_days"]
+                    name=mission_data["name"],
+                    description=mission_data["description"],
+                    mission_type=mission_data["mission_type"],
+                    target_value=mission_data["target_value"],
+                    reward_points=mission_data["reward_points"],
+                    duration_days=mission_data["duration_days"]
                 )
                 created_missions.append(mission.name)
             

--- a/mybot/utils/message_utils.py
+++ b/mybot/utils/message_utils.py
@@ -2,7 +2,8 @@
 from aiogram.types import Message, InlineKeyboardMarkup
 from aiogram.exceptions import TelegramBadRequest
 import logging
-from database.models import User, Mission, Reward, UserAchievement
+from database.models import User, Reward, UserAchievement
+from mybot.models import Mission
 from services.level_service import LevelService
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
@@ -127,7 +128,7 @@ async def get_mission_details_message(mission: Mission) -> str:
         mission_name=mission.name,
         mission_description=mission.description,
         points_reward=mission.reward_points,
-        mission_type=mission.type.capitalize(),
+        mission_type=mission.mission_type.capitalize(),
     )
 
 

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -37,12 +37,12 @@ async def main() -> None:
         if not existing:
             for m in DEFAULT_MISSIONS:
                 await mission_service.create_mission(
-                    m["name"],
-                    m["description"],
-                    m["mission_type"],
-                    m.get("target_value", 1),
-                    m["reward_points"],
-                    m.get("duration_days", 0),
+                    name=m["name"],
+                    description=m["description"],
+                    mission_type=m["mission_type"],
+                    target_value=m.get("target_value", 1),
+                    reward_points=m["reward_points"],
+                    duration_days=m.get("duration_days", 0),
                 )
     print("Database initialised")
 


### PR DESCRIPTION
## Summary
- use new Mission model and adjust imports
- create missions without specifying the id
- accept mission ids as integers in MissionService
- display mission type correctly in admin menus
- update scripts and services to use keyword params

## Testing
- `flake8 mybot | head` *(fails: E501 line too long)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_685d702da6108329bd4b5d65a6f5deed