### PR TITLE
Fix mission creation with auto-generated ID

### DIFF
--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -203,9 +203,7 @@ class MissionService:
         requires_action: bool = False,
         action_data: dict | None = None,
     ) -> Mission:
-        mission_id = f"{mission_type}_{sanitize_text(name).lower().replace(' ', '_').replace('.', '').replace(',', '')}"
         new_mission = Mission(
-            id=mission_id,
             name=sanitize_text(name),
             description=sanitize_text(description),
             reward_points=reward_points,


### PR DESCRIPTION
## Summary
- avoid passing a manual string ID when creating Mission records

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d81c1386c8329a65a696260260ec4