### PR TITLE
Fix channel_type null violation in mission creation

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -105,6 +105,7 @@ class Mission(AsyncAttrs, Base):
     id = Column(String, primary_key=True, unique=True)
     name = Column(String, nullable=False)
     description = Column(Text)
+    channel_type = Column(String, nullable=False, default="vip")
     reward_points = Column(Integer, default=0)
     type = Column(String, default="one_time")
     target_value = Column(Integer, default=1)

--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -324,6 +324,7 @@ async def admin_process_duration(message: Message, state: FSMContext, session: A
         data["target"],
         data["reward"],
         days,
+        channel_type="vip",
     )
     await message.answer(
         "✅ Misión creada correctamente", reply_markup=get_admin_content_missions_keyboard()

--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -114,6 +114,7 @@ class MessageService:
                 target_value=1,
                 reward_points=1,
                 duration_days=7,
+                channel_type=channel_type,
                 requires_action=True,
                 action_data={"target_message_id": real_message_id},
             )

--- a/mybot/services/minigame_service.py
+++ b/mybot/services/minigame_service.py
@@ -37,7 +37,15 @@ class MiniGameService:
         await self.session.commit()
         return score
 
-    async def start_reaction_challenge(self, user_id: int, reactions: int, duration_minutes: int = 10, reward: int = 5, penalty: int = 2) -> Mission:
+    async def start_reaction_challenge(
+        self,
+        user_id: int,
+        reactions: int,
+        duration_minutes: int = 10,
+        reward: int = 5,
+        penalty: int = 2,
+        channel_type: str = "vip",
+    ) -> Mission:
         ms = MissionService(self.session)
         mission_name = f"Reaction Challenge {user_id}"
         description = f"Reacciona {reactions} veces en {duration_minutes} minutos"
@@ -48,6 +56,7 @@ class MiniGameService:
             reactions,
             reward,
             duration_days=0,
+            channel_type=channel_type,
             requires_action=False,
             action_data={"duration_minutes": duration_minutes, "penalty_points": penalty},
         )

--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -199,6 +199,7 @@ class MissionService:
         target_value: int,
         reward_points: int,
         duration_days: int = 0,
+        channel_type: str = "vip",
         *,
         requires_action: bool = False,
         action_data: dict | None = None,
@@ -206,6 +207,7 @@ class MissionService:
         new_mission = Mission(
             name=sanitize_text(name),
             description=sanitize_text(description),
+            channel_type=channel_type,
             reward_points=reward_points,
             type=mission_type,
             target_value=target_value,

--- a/mybot/services/tenant_service.py
+++ b/mybot/services/tenant_service.py
@@ -216,7 +216,8 @@ class TenantService:
                     mission_data["mission_type"],
                     mission_data["target_value"],
                     mission_data["reward_points"],
-                    mission_data["duration_days"]
+                    mission_data["duration_days"],
+                    channel_type="vip"
                 )
                 created_missions.append(mission.name)
             

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -43,6 +43,7 @@ async def main() -> None:
                     m.get("target_value", 1),
                     m["reward_points"],
                     m.get("duration_days", 0),
+                    channel_type="vip",
                 )
     print("Database initialised")
 


### PR DESCRIPTION
## Summary
- extend `Mission` model with `channel_type`
- require `channel_type` when creating missions
- propagate new argument through services and handlers
- default to `vip` for automatically generated missions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8f7716908329b4d2b045864d4f0b