### PR TITLE
Fix mission models fields

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -102,12 +102,12 @@ class UserAchievement(AsyncAttrs, Base):
 
 class Mission(AsyncAttrs, Base):
     __tablename__ = "missions"
-    id = Column(String, primary_key=True, unique=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False)
-    description = Column(Text)
+    description = Column(Text, nullable=False)
     channel_type = Column(String, nullable=False, default="vip")
     reward_points = Column(Integer, default=0)
-    type = Column(String, default="one_time")
+    mission_type = Column("mission_type", String, default="one_time")
     target_value = Column(Integer, default=1)
     duration_days = Column(Integer, default=0)
     is_active = Column(Boolean, default=True)

--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -272,7 +272,7 @@ async def admin_select_mission_type(callback: CallbackQuery, state: FSMContext):
         "login": "login_streak",
         "custom": "custom",
     }
-    await state.update_data(type=mapping.get(m_type, m_type))
+    await state.update_data(mission_type=mapping.get(m_type, m_type))
     await callback.message.edit_text("📊 Cantidad requerida")
     await state.set_state(AdminMissionStates.creating_mission_target)
     await callback.answer()
@@ -320,7 +320,7 @@ async def admin_process_duration(message: Message, state: FSMContext, session: A
     await mission_service.create_mission(
         data["name"],
         data["description"],
-        data["type"],
+        data["mission_type"],
         data["target"],
         data["reward"],
         days,

--- a/mybot/handlers/admin/missions_admin.py
+++ b/mybot/handlers/admin/missions_admin.py
@@ -70,7 +70,7 @@ async def mission_view_details(callback: CallbackQuery, session: AsyncSession):
         "🔹 **Descripción:**",
         f"💬 {mission.description or '-'}",
         "",
-        f"🔸 **Tipo de Misión:** `{mission.type}`",
+        f"🔸 **Tipo de Misión:** `{mission.mission_type}`",
         f"🔸 **Puntos que Ganas:** {points_text}",
         f"🔸 **Estado:** {status_text}",
     ]

--- a/mybot/models/__init__.py
+++ b/mybot/models/__init__.py
@@ -1,4 +1,5 @@
 from .mission import Mission
 from .pista import Pista
 from .backpack_item import BackpackItem
+from .user_mission_entry import UserMissionEntry
 

--- a/mybot/models/mission.py
+++ b/mybot/models/mission.py
@@ -19,7 +19,9 @@ class Mission(AsyncAttrs, Base):
     name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     channel_type: Mapped[str] = mapped_column(String(50), nullable=False)
-    mission_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    mission_type: Mapped[str] = mapped_column(
+        "mission_type", String(50), nullable=False
+    )
     reward_type: Mapped[str] = mapped_column(String(50), nullable=False)
     reward_amount: Mapped[float] = mapped_column(Integer, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/mybot/models/user_mission_entry.py
+++ b/mybot/models/user_mission_entry.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from sqlalchemy import Integer, BigInteger, ForeignKey, DateTime, Boolean, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.ext.asyncio import AsyncAttrs
+import datetime
+
+from database.models import Base
+
+
+class UserMissionEntry(AsyncAttrs, Base):
+    """Track mission progress and completion per user."""
+
+    __tablename__ = "user_mission_entries"
+    __table_args__ = (
+        UniqueConstraint("user_id", "mission_id", name="uix_user_mission_entry"),
+        {"extend_existing": True},
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
+    mission_id: Mapped[int] = mapped_column(Integer, ForeignKey("missions.id"))
+    progress_value: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    completed: Mapped[bool] = mapped_column(Boolean, default=False)
+    completed_at: Mapped[datetime.datetime | None] = mapped_column(DateTime, nullable=True)

--- a/mybot/utils/message_utils.py
+++ b/mybot/utils/message_utils.py
@@ -127,7 +127,7 @@ async def get_mission_details_message(mission: Mission) -> str:
         mission_name=mission.name,
         mission_description=mission.description,
         points_reward=mission.reward_points,
-        mission_type=mission.type.capitalize(),
+        mission_type=mission.mission_type.capitalize(),
     )
 
 


### PR DESCRIPTION
## Summary
- update DB Mission model to use mission_type column and autoincrement id
- sync ORM models and services with the new mission_type field
- add UserMissionEntry dataclass in models package
- update admin handlers to use mission_type

## Testing
- `python -m py_compile mybot/models/mission.py mybot/models/user_mission_entry.py mybot/models/__init__.py mybot/database/models.py mybot/services/mission_service.py mybot/utils/message_utils.py mybot/handlers/admin/game_admin.py mybot/handlers/admin/missions_admin.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_685d943b48108329957749471c7bf752