### PR TITLE
Fix imports to avoid mybot module references

### DIFF
--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -36,7 +36,7 @@ from services.mission_service import MissionService
 from services.reward_service import RewardService
 from services.level_service import LevelService
 from database.models import User, Level
-from mybot.models import Mission
+from models import Mission
 from services.point_service import PointService
 from services.config_service import ConfigService
 from services.badge_service import BadgeService

--- a/mybot/handlers/admin/missions_admin.py
+++ b/mybot/handlers/admin/missions_admin.py
@@ -10,7 +10,7 @@ from utils.keyboard_utils import get_admin_mission_list_keyboard, get_back_keybo
 from utils.admin_state import AdminMissionStates, MissionAdminStates
 from utils.message_utils import safe_edit_message
 from services.mission_service import MissionService
-from mybot.models import Mission
+from models import Mission
 from database.models import LorePiece
 
 router = Router()

--- a/mybot/services/minigame_service.py
+++ b/mybot/services/minigame_service.py
@@ -2,7 +2,7 @@ import datetime
 from aiogram import Bot
 from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import UserStats, MiniGamePlay, UserMissionEntry
-from mybot.models import Mission
+from models import Mission
 from .point_service import PointService
 from .mission_service import MissionService
 

--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -11,7 +11,7 @@ from database.models import (
     LorePiece,
     UserLorePiece,
 )
-from mybot.models import Mission
+from models import Mission
 from utils.text_utils import sanitize_text
 import logging
 

--- a/mybot/utils/message_utils.py
+++ b/mybot/utils/message_utils.py
@@ -3,7 +3,7 @@ from aiogram.types import Message, InlineKeyboardMarkup
 from aiogram.exceptions import TelegramBadRequest
 import logging
 from database.models import User, Reward, UserAchievement
-from mybot.models import Mission
+from models import Mission
 from services.level_service import LevelService
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
--r mybot/requirements.txt
+aiogram>=3.0.0
+SQLAlchemy
+aiosqlite
+APScheduler
+python-dotenv
+asyncpg

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,9 +1,9 @@
 import asyncio
 
-from mybot.database.setup import init_db, get_session
-from mybot.services.achievement_service import AchievementService
-from mybot.services.level_service import LevelService
-from mybot.services.mission_service import MissionService
+from database.setup import init_db, get_session
+from services.achievement_service import AchievementService
+from services.level_service import LevelService
+from services.mission_service import MissionService
 
 DEFAULT_MISSIONS = [
     {

--- a/scripts/setup_pistas.py
+++ b/scripts/setup_pistas.py
@@ -1,6 +1,6 @@
 import asyncio
 from sqlalchemy import select
-from mybot.database.setup import init_db, get_session
+from database.setup import init_db, get_session
 from models import Pista
 
 INITIAL_PISTA = {


### PR DESCRIPTION
## Summary
- remove `mybot.` prefixes in imports
- inline dependencies in `requirements.txt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_685e3f2914c88329bb7b0b3525d3e887