### PR TITLE
Fix Telegram entity errors

### DIFF
--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -70,8 +70,11 @@ async def show_users_page(message: Message, session: AsyncSession, offset: int) 
         "",
     ]
 
+    from utils.text_utils import escape_html
+
     for user in users:
-        display = user.username or (user.first_name or "Sin nombre")
+        raw_display = user.username or (user.first_name or "Sin nombre")
+        display = escape_html(raw_display)
         text_lines.append(f"- {display} (ID: {user.id}) - {user.points} pts")
 
     keyboard = get_admin_users_list_keyboard(users, offset, total_users, limit)
@@ -158,7 +161,10 @@ async def admin_view_user(callback: CallbackQuery, session: AsyncSession):
     if not user:
         await callback.answer("Usuario no encontrado", show_alert=True)
         return
-    display = user.username or (user.first_name or "Sin nombre")
+    from utils.text_utils import escape_html
+
+    raw_display = user.username or (user.first_name or "Sin nombre")
+    display = escape_html(raw_display)
     await callback.message.answer(f"Perfil de {display}\nPuntos: {user.points}")
     await callback.answer()
 
@@ -197,8 +203,11 @@ async def process_search_user(message: Message, state: FSMContext, session: Asyn
     if not users:
         await send_temporary_reply(message, "No se encontraron usuarios.")
     else:
+        from utils.text_utils import escape_html
+
         response = "Resultados:\n" + "\n".join(
-            f"- {(u.username or u.first_name or 'Sin nombre')} (ID: {u.id})" for u in users
+            f"- {escape_html(u.username or u.first_name or 'Sin nombre')} (ID: {u.id})"
+            for u in users
         )
         await message.answer(response)
     await state.clear()

--- a/mybot/services/free_channel_service.py
+++ b/mybot/services/free_channel_service.py
@@ -270,10 +270,14 @@ class FreeChannelService:
             reply_markup: Teclado inline opcional
             media_files: Lista de archivos multimedia [{'type': 'photo/video/document/audio', 'file_id': 'xxx', 'caption': 'xxx'}]
         """
+        from utils.text_utils import escape_markdown
+
         free_channel_id = await self.get_free_channel_id()
         if not free_channel_id:
             logger.error("Free channel not configured")
             return None
+
+        safe_text = escape_markdown(text or "")
         
         try:
             # Si hay archivos multimedia, enviar como álbum
@@ -283,6 +287,7 @@ class FreeChannelService:
                     media_type = media.get('type', 'photo')
                     file_id = media.get('file_id')
                     caption = media.get('caption', text if i == 0 else None)
+                    caption = escape_markdown(caption) if caption else None
                     
                     if media_type == 'photo':
                         media_group.append(InputMediaPhoto(media=file_id, caption=caption))
@@ -312,7 +317,7 @@ class FreeChannelService:
                     sent_message = await self.bot.send_photo(
                         chat_id=free_channel_id,
                         photo=file_id,
-                        caption=text,
+                        caption=safe_text,
                         reply_markup=reply_markup,
                         protect_content=protect_content,
                         parse_mode="Markdown"
@@ -321,7 +326,7 @@ class FreeChannelService:
                     sent_message = await self.bot.send_video(
                         chat_id=free_channel_id,
                         video=file_id,
-                        caption=text,
+                        caption=safe_text,
                         reply_markup=reply_markup,
                         protect_content=protect_content,
                         parse_mode="Markdown"
@@ -330,7 +335,7 @@ class FreeChannelService:
                     sent_message = await self.bot.send_document(
                         chat_id=free_channel_id,
                         document=file_id,
-                        caption=text,
+                        caption=safe_text,
                         reply_markup=reply_markup,
                         protect_content=protect_content,
                         parse_mode="Markdown"
@@ -339,7 +344,7 @@ class FreeChannelService:
                     sent_message = await self.bot.send_audio(
                         chat_id=free_channel_id,
                         audio=file_id,
-                        caption=text,
+                        caption=safe_text,
                         reply_markup=reply_markup,
                         protect_content=protect_content,
                         parse_mode="Markdown"
@@ -348,7 +353,7 @@ class FreeChannelService:
                     # Fallback a mensaje de texto
                     sent_message = await self.bot.send_message(
                         chat_id=free_channel_id,
-                        text=text,
+                        text=safe_text,
                         reply_markup=reply_markup,
                         protect_content=protect_content,
                         parse_mode="Markdown"
@@ -357,7 +362,7 @@ class FreeChannelService:
                 # Mensaje de texto simple
                 sent_message = await self.bot.send_message(
                     chat_id=free_channel_id,
-                    text=text,
+                    text=safe_text,
                     reply_markup=reply_markup,
                     protect_content=protect_content,
                     parse_mode="Markdown"

--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -64,9 +64,13 @@ class MessageService:
         try:
             raw_reactions, _ = await self.channel_service.get_reactions_and_points(target_channel_id)
 
+            from utils.text_utils import escape_html
+
+            safe_text = escape_html(text)
+
             sent = await self.bot.send_message(
                 chat_id=target_channel_id_str,
-                text=text,
+                text=safe_text,
                 reply_markup=None,
             )
 

--- a/mybot/utils/notify_admins.py
+++ b/mybot/utils/notify_admins.py
@@ -1,11 +1,14 @@
 import logging
 from aiogram import Bot
 from utils.config import ADMIN_IDS
+from utils.text_utils import escape_html
 
 
 async def notify_admins(bot: Bot, text: str) -> None:
+    """Send a notification to all admins escaping HTML characters."""
+    safe_text = escape_html(text)
     for admin_id in ADMIN_IDS:
         try:
-            await bot.send_message(admin_id, text)
+            await bot.send_message(admin_id, safe_text, parse_mode="HTML")
         except Exception as e:
             logging.error(f"Failed to notify admin {admin_id}: {e}")

--- a/mybot/utils/text_utils.py
+++ b/mybot/utils/text_utils.py
@@ -152,3 +152,31 @@ def escape_markdown_v2(text: str) -> str:
     for old, new in replacements:
         text = text.replace(old, new)
     return text
+
+
+def escape_markdown(text: str) -> str:
+    """Escape special characters for Telegram Markdown."""
+    if not isinstance(text, str):
+        text = str(text)
+
+    replacements = [
+        ("\\", "\\\\"),
+        ("`", "\\`"),
+        ("*", "\\*"),
+        ("_", "\\_"),
+        ("[", "\\["),
+        ("]", "\\]"),
+    ]
+
+    for old, new in replacements:
+        text = text.replace(old, new)
+    return text
+
+
+def escape_html(text: str | None) -> str:
+    """Escape text for HTML parse mode."""
+    from html import escape
+
+    if text is None:
+        return ""
+    return escape(str(text))


### PR DESCRIPTION
## Summary
- sanitize text for Markdown and HTML messages
- update admin notifications to escape HTML
- protect free channel posts with Markdown escaping
- escape HTML when sending interactive posts and admin user displays

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ea450f1608329963ff5fd57deacc8