### PR TITLE
Fix mission creation reward type default

### DIFF
--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -198,18 +198,22 @@ class MissionService:
         mission_type: str,
         target_value: int,
         reward_points: int,
+        reward_type: str | None = None,
         duration_days: int = 0,
         *,
         channel_type: str | None = None,
         requires_action: bool = False,
         action_data: dict | None = None,
     ) -> Mission:
+        if reward_type is None:
+            reward_type = "points"
         if channel_type is None:
             channel_type = "general"
         new_mission = Mission(
             name=sanitize_text(name),
             description=sanitize_text(description),
             reward_points=reward_points,
+            reward_type=reward_type,
             channel_type=channel_type,
             mission_type=mission_type,
             target_value=target_value,


### PR DESCRIPTION
## Summary
- ensure missions always have a reward_type

## Testing
- `python -m pip install -r requirements.txt`
- `python -m compileall mybot`

------
https://chatgpt.com/codex/tasks/task_e_685ea854927483298797a053ec8fe6c9