### PR TITLE
Add Hint model

### DIFF
--- a/mybot/database/hint_model.py
+++ b/mybot/database/hint_model.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime, func
+from sqlalchemy.ext.asyncio import AsyncAttrs
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+class Hint(AsyncAttrs, Base):
+    __tablename__ = "hints"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    code_name = Column(String, unique=True, nullable=False)
+    hint_type = Column(String, nullable=False)  # 'text', 'image', 'video'
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=func.now())


### PR DESCRIPTION
## Summary
- add standalone Hint ORM model

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile mybot/database/hint_model.py`

------
https://chatgpt.com/codex/tasks/task_e_685ee3308a28832993cdda32f9de29f0