### PR TITLE
Add HintCombination model

### DIFF
--- a/mybot/database/hint_combination.py
+++ b/mybot/database/hint_combination.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, DateTime, func
+from sqlalchemy.ext.asyncio import AsyncAttrs
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+class HintCombination(AsyncAttrs, Base):
+    __tablename__ = "hint_combinations"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    combination_code = Column(String, unique=True, nullable=False)  # Código que representa la combinación correcta
+    required_hints = Column(String, nullable=False)  # IDs o códigos separados por coma, ejemplo: "2,4,7"
+    reward_code = Column(String, nullable=False)  # Código de la pista o recompensa que se desbloquea
+    created_at = Column(DateTime, default=func.now())


### PR DESCRIPTION
## Summary
- define new SQLAlchemy model `HintCombination` for storing combinations of hints

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ee984ab1083298e493c25843173d0