### PR TITLE
Fix imports referencing mybot package

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -24,7 +24,7 @@ from handlers import setup as setup_handlers # ¡IMPORTACIÓN CLAVE!
 
 from handlers.free_channel_admin import router as free_channel_admin_router
 from handlers.publication_test import router as publication_test_router
-from mybot import mochila
+import mochila
 
 from utils.config import BOT_TOKEN, VIP_CHANNEL_ID
 from services import (

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,9 +1,17 @@
 import asyncio
+import os
+import sys
 
-from mybot.database.setup import init_db, get_session
-from mybot.services.achievement_service import AchievementService
-from mybot.services.level_service import LevelService
-from mybot.services.mission_service import MissionService
+# Añadimos la raíz del proyecto al sys.path para permitir las importaciones
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, os.pardir))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from database.setup import init_db, get_session
+from services.achievement_service import AchievementService
+from services.level_service import LevelService
+from services.mission_service import MissionService
 
 DEFAULT_MISSIONS = [
     {


### PR DESCRIPTION
## Summary
- import local modules without the `mybot` package prefix
- enable scripts to import modules by adding the repo root to `sys.path`

## Testing
- `python -m py_compile mybot/bot.py scripts/init_db.py`

------
https://chatgpt.com/codex/tasks/task_e_685eeacbd22c832993fb1b544f097e84