### PR TITLE
Move hints admin button to main menu

### DIFF
--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -679,7 +679,6 @@ async def admin_content_minigames(callback: CallbackQuery, session: AsyncSession
     keyboard = InlineKeyboardMarkup(
         inline_keyboard=[
             [InlineKeyboardButton(text=toggle_text, callback_data="toggle_minigames")],
-            [InlineKeyboardButton(text="🎒 Administrar Pistas", callback_data="admin_manage_hints")],
             [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
         ]
     )

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -230,6 +230,12 @@ def get_admin_manage_content_keyboard():
             ],
             [
                 InlineKeyboardButton(
+                    text="🎒 Administrar Pistas",
+                    callback_data="admin_content_lore_pieces",
+                )
+            ],
+            [
+                InlineKeyboardButton(
                     text="🎉 Eventos y Sorteos",
                     callback_data="admin_manage_events_sorteos",
                 )


### PR DESCRIPTION
## Summary
- add "Administrar Pistas" button to the main Juego Kinky admin menu
- remove that button from the minigames submenu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_685efdf15ed48329996acd284004a749