### PR TITLE
Add lore pieces admin listing

### DIFF
--- a/mybot/utils/pagination.py
+++ b/mybot/utils/pagination.py
@@ -1,0 +1,11 @@
+from aiogram.types import InlineKeyboardButton
+
+
+def get_pagination_buttons(page: int, total_pages: int, prefix: str) -> list[InlineKeyboardButton]:
+    """Return navigation buttons for a paginated list."""
+    buttons: list[InlineKeyboardButton] = []
+    if page > 0:
+        buttons.append(InlineKeyboardButton(text="⬅️", callback_data=f"{prefix}:{page-1}"))
+    if page + 1 < total_pages:
+        buttons.append(InlineKeyboardButton(text="➡️", callback_data=f"{prefix}:{page+1}"))
+    return buttons


### PR DESCRIPTION
## Summary
- list LorePiece objects in admin menu with pagination
- add pagination helper

## Testing
- `python -m py_compile mybot/utils/pagination.py mybot/handlers/admin/game_admin.py`

------
https://chatgpt.com/codex/tasks/task_e_685f01f4ea588329be70887392d6b199