### PR TITLE
Add FSM to create Lore pieces

### DIFF
--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -14,6 +14,7 @@ from .raffle_service import RaffleService
 from .message_service import MessageService
 from .auction_service import AuctionService
 from .user_service import UserService
+from .lore_piece_service import LorePieceService
 from .scheduler import channel_request_scheduler, vip_subscription_scheduler, vip_membership_scheduler
 
 __all__ = [
@@ -38,4 +39,5 @@ __all__ = [
     "MessageService",
     "AuctionService",
     "UserService",
+    "LorePieceService",
 ]

--- a/mybot/services/lore_piece_service.py
+++ b/mybot/services/lore_piece_service.py
@@ -1,0 +1,37 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from database.models import LorePiece
+
+class LorePieceService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def code_exists(self, code_name: str) -> bool:
+        stmt = select(LorePiece).where(LorePiece.code_name == code_name)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+
+    async def create_lore_piece(
+        self,
+        code_name: str,
+        title: str,
+        content_type: str,
+        content: str,
+        *,
+        description: str | None = None,
+        category: str | None = None,
+        is_main_story: bool = False,
+    ) -> LorePiece:
+        piece = LorePiece(
+            code_name=code_name,
+            title=title,
+            description=description,
+            content_type=content_type,
+            content=content,
+            category=category,
+            is_main_story=is_main_story,
+        )
+        self.session.add(piece)
+        await self.session.commit()
+        await self.session.refresh(piece)
+        return piece

--- a/mybot/states/__init__.py
+++ b/mybot/states/__init__.py
@@ -1,0 +1,5 @@
+from .gamification_states import LorePieceAdminStates
+
+__all__ = [
+    "LorePieceAdminStates",
+]

--- a/mybot/states/gamification_states.py
+++ b/mybot/states/gamification_states.py
@@ -1,0 +1,11 @@
+from aiogram.fsm.state import StatesGroup, State
+
+class LorePieceAdminStates(StatesGroup):
+    creating_code_name = State()
+    creating_title = State()
+    creating_description = State()
+    creating_category = State()
+    confirming_main_story = State()
+    choosing_content_type = State()
+    entering_text_content = State()
+    uploading_file_content = State()


### PR DESCRIPTION
## Summary
- implement `LorePieceAdminStates` in new `states/gamification_states.py`
- add `LorePieceService` for database operations
- expose `LorePieceService` from services package
- extend `game_admin.py` with handlers to create lore pieces using FSM

## Testing
- `python -m py_compile mybot/handlers/admin/game_admin.py mybot/services/lore_piece_service.py mybot/states/gamification_states.py mybot/states/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685f03ca39888329ad86c686d29df9f5