### PR TITLE
Implement LorePiece editing FSM

### DIFF
--- a/mybot/services/lore_piece_service.py
+++ b/mybot/services/lore_piece_service.py
@@ -35,3 +35,37 @@ class LorePieceService:
         await self.session.commit()
         await self.session.refresh(piece)
         return piece
+
+    async def get_lore_piece_by_code(self, code_name: str) -> LorePiece | None:
+        stmt = select(LorePiece).where(LorePiece.code_name == code_name)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def update_lore_piece(
+        self,
+        code_name: str,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+        category: str | None = None,
+        is_main_story: bool | None = None,
+        content_type: str | None = None,
+        content: str | None = None,
+    ) -> bool:
+        piece = await self.get_lore_piece_by_code(code_name)
+        if not piece:
+            return False
+        if title is not None:
+            piece.title = title
+        if description is not None:
+            piece.description = description
+        if category is not None:
+            piece.category = category
+        if is_main_story is not None:
+            piece.is_main_story = is_main_story
+        if content_type is not None:
+            piece.content_type = content_type
+        if content is not None:
+            piece.content = content
+        await self.session.commit()
+        return True

--- a/mybot/states/gamification_states.py
+++ b/mybot/states/gamification_states.py
@@ -9,3 +9,12 @@ class LorePieceAdminStates(StatesGroup):
     choosing_content_type = State()
     entering_text_content = State()
     uploading_file_content = State()
+
+    # States for editing an existing lore piece
+    editing_title = State()
+    editing_description = State()
+    editing_category = State()
+    editing_is_main_story = State()
+    editing_content_type = State()
+    editing_text_content = State()
+    editing_file_content = State()


### PR DESCRIPTION
## Summary
- add editing states for LorePiece FSM
- expand `LorePieceService` with get and update functions
- implement handlers for editing lore pieces in the admin panel

## Testing
- `python -m py_compile mybot/handlers/admin/game_admin.py mybot/services/lore_piece_service.py mybot/states/gamification_states.py`

------
https://chatgpt.com/codex/tasks/task_e_685f15ba220c8329804f6a3a7d350d85