### PR TITLE
Add lore piece deletion with confirmation

### DIFF
--- a/mybot/services/lore_piece_service.py
+++ b/mybot/services/lore_piece_service.py
@@ -69,3 +69,11 @@ class LorePieceService:
             piece.content = content
         await self.session.commit()
         return True
+
+    async def delete_lore_piece(self, code_name: str) -> bool:
+        piece = await self.get_lore_piece_by_code(code_name)
+        if not piece:
+            return False
+        await self.session.delete(piece)
+        await self.session.commit()
+        return True


### PR DESCRIPTION
## Summary
- add `delete_lore_piece` method to service
- allow admins to delete lore pieces with confirmation step

## Testing
- `python -m py_compile mybot/handlers/admin/game_admin.py mybot/services/lore_piece_service.py`

------
https://chatgpt.com/codex/tasks/task_e_685f1e7a16448329bfae6f9ed696ac7f