### PR TITLE
Add backpack router to bot

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -25,6 +25,7 @@ from handlers.free_channel_admin import router as free_channel_admin_router
 from handlers.publication_test import router as publication_test_router
 import mochila
 import combinar_pistas
+import backpack
 
 from utils.config import BOT_TOKEN, VIP_CHANNEL_ID
 from services import (
@@ -96,6 +97,7 @@ async def main() -> None:
     dp.include_router(free_user.router)
     dp.include_router(lore_router)
     dp.include_router(mochila.router)
+    dp.include_router(backpack.router)
     dp.include_router(combinar_pistas.router)
     dp.include_router(channel_access_router)
 


### PR DESCRIPTION
## Summary
- import `backpack` module
- register `backpack.router` with the dispatcher

## Testing
- `python -m py_compile mybot/bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685f373a4c9083299b69def348854258