### PR TITLE
Add backpack access button

### DIFF
--- a/mybot/backpack.py
+++ b/mybot/backpack.py
@@ -126,6 +126,13 @@ async def mostrar_mochila_narrativa(message: Message):
         
         await message.answer(texto, reply_markup=InlineKeyboardMarkup(inline_keyboard=keyboard), parse_mode="Markdown")
 
+
+@router.callback_query(F.data == "open_backpack")
+async def open_backpack(callback: CallbackQuery):
+    """Handler to open the backpack from inline buttons."""
+    await mostrar_mochila_narrativa(callback.message)
+    await callback.answer()
+
 async def mostrar_mochila_vacia(message: Message):
     """Mensaje especial para mochila vacía con contexto narrativo"""
     texto = """🎩 **Lucien:**

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -18,6 +18,7 @@ def get_main_menu_keyboard():
         [InlineKeyboardButton(text="🎁 Recompensas", callback_data="menu:rewards")],
         [InlineKeyboardButton(text="🏛️ Subastas", callback_data="auction_main")],
         [InlineKeyboardButton(text="🏆 Ranking", callback_data="menu:ranking")],
+        [InlineKeyboardButton(text="🎒 Mochila", callback_data="open_backpack")],
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 


### PR DESCRIPTION
## Summary
- add `🎒 Mochila` button to main menu keyboard
- handle `open_backpack` callback to show backpack

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_685f384e269c83299563c8640b4503ec