### PR TITLE
Add main menu keyboard with backpack support

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -4,6 +4,25 @@ from aiogram import Bot, Dispatcher
 from aiogram.enums.parse_mode import ParseMode
 from aiogram.client.bot import DefaultBotProperties
 from aiogram.fsm.storage.memory import MemoryStorage
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+
+# --- INICIO DE LA DEFINICIÓN DEL TECLADO PRINCIPAL ---
+main_menu_keyboard = ReplyKeyboardMarkup(
+    keyboard=[
+        [
+            KeyboardButton(text="🎒 Mochila"),
+            KeyboardButton(text="💰 Billetera"),
+            KeyboardButton(text="🎯 Misiones"),
+        ],
+        [
+            KeyboardButton(text="⚙️ Configuración"),
+            KeyboardButton(text="❓ Ayuda"),
+        ],
+    ],
+    resize_keyboard=True,
+    one_time_keyboard=False,
+)
+# --- FIN DE LA DEFINICIÓN DEL TECLADO PRINCIPAL ---
 
 from database.setup import init_db, get_session
 

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -4,6 +4,7 @@ Enhanced start handler with improved user experience and multi-tenant support.
 from aiogram import Router
 from aiogram.filters import CommandStart
 from aiogram.types import Message
+from bot import main_menu_keyboard
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.models import User
@@ -94,6 +95,10 @@ async def cmd_start(message: Message, session: AsyncSession):
             "admin_main", # Asegúrate de registrar el estado correcto
             delete_origin_message=True
         )
+        await message.answer(
+            "¡Bienvenido! Aquí tienes las opciones principales:",
+            reply_markup=main_menu_keyboard,
+        )
         return # Terminar aquí para el flujo de administración
     
     # Lógica para usuarios no-administradores (VIP, Free)
@@ -113,14 +118,18 @@ async def cmd_start(message: Message, session: AsyncSession):
                 text = "🌟 **¡Hola de nuevo!**\n\n" + text.split('\n\n', 1)[-1]
         
         await menu_manager.show_menu(
-            message, 
-            text, 
-            keyboard, 
-            session, 
+            message,
+            text,
+            keyboard,
+            session,
             "main",
             delete_origin_message=True
         )
-        
+        await message.answer(
+            "¡Bienvenido! Aquí tienes las opciones principales:",
+            reply_markup=main_menu_keyboard,
+        )
+
     except Exception as e:
         logger.error(f"Error in start command for user {user_id}: {e}")
         await menu_manager.send_temporary_message(


### PR DESCRIPTION
## Summary
- add `main_menu_keyboard` ReplyKeyboardMarkup in `bot.py`
- display the keyboard after `/start` for all roles
- import keyboard in start handler
- ensure backpack listens to "🎒 Mochila" messages

## Testing
- `python -m py_compile mybot/bot.py mybot/handlers/start.py mybot/backpack.py`


------
https://chatgpt.com/codex/tasks/task_e_685f5299820c832983f2ae6af69f3345