### PR TITLE
Fix reply keyboard display with inline menu

### DIFF
--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -95,9 +95,13 @@ async def cmd_start(message: Message, session: AsyncSession):
             "admin_main", # Asegúrate de registrar el estado correcto
             delete_origin_message=True
         )
-        await message.answer(
-            "¡Bienvenido! Aquí tienes las opciones principales:",
-            reply_markup=main_menu_keyboard,
+        # Display the reply keyboard without cluttering the chat
+        await menu_manager.send_temporary_message(
+            message,
+            "​",
+            keyboard=main_menu_keyboard,
+            auto_delete_seconds=0,
+            parse_mode="Markdown",
         )
         return # Terminar aquí para el flujo de administración
     
@@ -125,9 +129,13 @@ async def cmd_start(message: Message, session: AsyncSession):
             "main",
             delete_origin_message=True
         )
-        await message.answer(
-            "¡Bienvenido! Aquí tienes las opciones principales:",
-            reply_markup=main_menu_keyboard,
+        # Show the reply keyboard silently so it coexists with the inline menu
+        await menu_manager.send_temporary_message(
+            message,
+            "​",
+            keyboard=main_menu_keyboard,
+            auto_delete_seconds=0,
+            parse_mode="Markdown",
         )
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- preserve existing inline menu when showing reply keyboard
- remove visible text when displaying keyboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f55e8bba48329a8b207a56082e516