### PR TITLE
Add handlers for missions and guide callbacks

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -37,6 +37,8 @@ from handlers.reaction_callback import router as reaction_callback_router
 from handlers.admin import admin_router
 from handlers.admin.auction_admin import router as auction_admin_router
 from handlers.lore_handlers import router as lore_router
+from handlers.missions_handler import router as missions_router
+from handlers.info_handler import router as info_router
 
 from handlers import setup as setup_handlers # ¡IMPORTACIÓN CLAVE!
 
@@ -103,6 +105,8 @@ async def main() -> None:
     dp.include_router(start_token)
     dp.include_router(start.router)
     dp.include_router(backpack_router)
+    dp.include_router(missions_router)
+    dp.include_router(info_router)
     dp.include_router(admin_router)
     dp.include_router(auction_admin_router)
     dp.include_router(free_channel_admin_router)  # Nuevo router para canal gratuito

--- a/mybot/handlers/info_handler.py
+++ b/mybot/handlers/info_handler.py
@@ -1,0 +1,12 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery
+
+router = Router()
+
+@router.callback_query(F.data == "guia_principiante")
+async def show_travel_guide(callback: CallbackQuery):
+    """Placeholder para la guía del viajero."""
+    await callback.answer(
+        "La Guía del Viajero aún está en desarrollo. ¡Pronto estará disponible!",
+        show_alert=True,
+    )

--- a/mybot/handlers/missions_handler.py
+++ b/mybot/handlers/missions_handler.py
@@ -1,0 +1,28 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.mission_service import MissionService
+from database.models import User
+
+router = Router()
+
+@router.callback_query(F.data == "misiones_disponibles")
+async def show_available_missions(callback: CallbackQuery, session: AsyncSession):
+    """Muestra la lista de misiones disponibles para el usuario."""
+    await callback.answer("Cargando misiones...", show_alert=False)
+
+    mission_service = MissionService(session)
+    missions = await mission_service.get_active_missions(user_id=callback.from_user.id)
+
+    if not missions:
+        missions_text = "No hay misiones disponibles actualmente."
+    else:
+        user = await session.get(User, callback.from_user.id)
+        missions_text = "Aquí están tus misiones actuales:\n\n"
+        for m in missions:
+            completed, _ = await mission_service.check_mission_completion_status(user, m)
+            status = "✅" if completed else "❌"
+            missions_text += f"• {m.name} ({m.reward_points} pts) {status}\n"
+
+    await callback.message.edit_text(missions_text)


### PR DESCRIPTION
## Summary
- implement callback query handlers for `misiones_disponibles` and `guia_principiante`
- wire the new routers into the bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f5bd72c7083299f2b199cb92a0154