### PR TITLE
Fix admin import path

### DIFF
--- a/mybot/handlers/admin_commands.py
+++ b/mybot/handlers/admin_commands.py
@@ -5,7 +5,7 @@ from aiogram.types import Message
 from aiogram.filters import Command
 from sqlalchemy import select
 from database.models import LorePiece, UserLorePiece, User
-from database import get_session
+from database.setup import get_session
 from backpack import desbloquear_pista_narrativa
 import random
 from datetime import datetime


### PR DESCRIPTION
## Summary
- fix `get_session` import in admin_commands handler

## Testing
- `python -m py_compile mybot/handlers/admin_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_686021e5954c8329bc55d4f1b63ff9eb