### PR TITLE
Fix start menu validation

### DIFF
--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -96,13 +96,17 @@ async def cmd_start(message: Message, session: AsyncSession):
             delete_origin_message=True
         )
         # Display the reply keyboard without cluttering the chat
-        await menu_manager.send_temporary_message(
-            message,
-            "​",
-            keyboard=main_menu_keyboard,
-            auto_delete_seconds=0,
-            parse_mode="Markdown",
-        )
+        text_to_send = "​"
+        if text_to_send and text:
+            await menu_manager.send_temporary_message(
+                message,
+                text_to_send,
+                keyboard=main_menu_keyboard,
+                auto_delete_seconds=0,
+                parse_mode="Markdown",
+            )
+        else:
+            logger.error("Empty text_to_send or menu text when sending reply keyboard")
         return # Terminar aquí para el flujo de administración
     
     # Lógica para usuarios no-administradores (VIP, Free)

--- a/mybot/utils/menu_manager.py
+++ b/mybot/utils/menu_manager.py
@@ -170,6 +170,13 @@ class MenuManager:
         """
         user_id = message.from_user.id
         bot = message.bot
+
+        # Validate text before sending
+        if not text or not text.strip():
+            logger.error(
+                f"Attempted to send empty temporary message to user {user_id}"
+            )
+            return None
         
         # Clean up previous temporary message
         await self._cleanup_temp_messages(bot, user_id)


### PR DESCRIPTION
## Summary
- prevent sending empty temporary messages
- check text before sending reply keyboard in `start`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68605293e86083298d88d46f0ac23021