### PR TITLE
Add trivia scheduler

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
 DATABASE_URL=postgresql+asyncpg://postgres:QTrweymKNskWGTuPHGyGhBzCKUHfYyoZ@postgres.railway.internal:5432/railway
+
+CANAL_KINKYS_ID=0
+CANAL_DIVAN_ID=0

--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -44,7 +44,8 @@ from handlers import setup as setup_handlers # ¡IMPORTACIÓN CLAVE!
 
 from handlers.free_channel_admin import router as free_channel_admin_router
 from handlers.publication_test import router as publication_test_router
-from mybot.trivia_router import router as trivia_router
+from mybot.routers import trivia_router
+from mybot.schedulers.trivia_scheduler import trivia_scheduler_worker
 import combinar_pistas
 from backpack import router as backpack_router
 
@@ -130,6 +131,7 @@ async def main() -> None:
     membership_task = asyncio.create_task(vip_membership_scheduler(bot, Session))
     auction_task = asyncio.create_task(auction_monitor_scheduler(bot, Session))
     cleanup_task = asyncio.create_task(free_channel_cleanup_scheduler(bot, Session))
+    trivia_task = asyncio.create_task(trivia_scheduler_worker(bot, Session))
 
     try:
         logging.info("Bot is starting polling...")
@@ -140,8 +142,9 @@ async def main() -> None:
         membership_task.cancel()
         auction_task.cancel()
         cleanup_task.cancel()
+        trivia_task.cancel()
         await asyncio.gather(
-            pending_task, vip_task, membership_task, auction_task, cleanup_task,
+            pending_task, vip_task, membership_task, auction_task, cleanup_task, trivia_task,
             return_exceptions=True
         )
 

--- a/mybot/routers/__init__.py
+++ b/mybot/routers/__init__.py
@@ -1,0 +1,1 @@
+from ..trivia_router import router as trivia_router

--- a/mybot/schedulers/trivia_scheduler.py
+++ b/mybot/schedulers/trivia_scheduler.py
@@ -1,0 +1,41 @@
+import asyncio
+import logging
+from aiogram import Bot
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+
+from services.trivia_service import TriviaService
+from utils.config import CANAL_KINKYS_ID, CANAL_DIVAN_ID
+
+
+async def _send_trivia(bot: Bot, session: AsyncSession, chat_id: int):
+    service = TriviaService(session)
+    question = await service.get_random_question()
+    if not question:
+        return
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text=opt, callback_data=f"trivia_{question['id']}_{i}")]
+            for i, opt in enumerate(question["options"])
+        ]
+    )
+    await bot.send_message(chat_id, question["question"], reply_markup=keyboard)
+
+
+async def trivia_scheduler_worker(bot: Bot, session_factory: async_sessionmaker[AsyncSession]):
+    """Background task to periodically post trivia questions."""
+    logging.info("Trivia scheduler started")
+    interval = 3600  # default: every hour
+    try:
+        while True:
+            async with session_factory() as session:
+                if CANAL_KINKYS_ID:
+                    await _send_trivia(bot, session, CANAL_KINKYS_ID)
+                if CANAL_DIVAN_ID and CANAL_DIVAN_ID != CANAL_KINKYS_ID:
+                    await _send_trivia(bot, session, CANAL_DIVAN_ID)
+            await asyncio.sleep(interval)
+    except asyncio.CancelledError:
+        logging.info("Trivia scheduler cancelled")
+        raise
+    except Exception:
+        logging.exception("Unhandled error in trivia scheduler")

--- a/mybot/utils/config.py
+++ b/mybot/utils/config.py
@@ -30,6 +30,10 @@ VIP_CHANNEL_ID = int(os.environ.get("VIP_CHANNEL_ID", "0"))
 # disables handling of free channel join requests.
 FREE_CHANNEL_ID = int(os.environ.get("FREE_CHANNEL_ID", "0"))
 
+# Optional channel IDs for broadcasting daily trivia.
+CANAL_KINKYS_ID = int(os.environ.get("CANAL_KINKYS_ID", "0"))
+CANAL_DIVAN_ID = int(os.environ.get("CANAL_DIVAN_ID", "0"))
+
 # Default scheduler intervals in seconds. These can be overridden via
 # environment variables and further adjusted at runtime using the admin
 # configuration menu.
@@ -48,6 +52,8 @@ class Config:
     ADMIN_ID = ADMIN_IDS[0] if ADMIN_IDS else 0
     CHANNEL_ID = VIP_CHANNEL_ID
     FREE_CHANNEL_ID = FREE_CHANNEL_ID
+    CANAL_KINKYS_ID = CANAL_KINKYS_ID
+    CANAL_DIVAN_ID = CANAL_DIVAN_ID
     DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///gamification.db")
     CHANNEL_SCHEDULER_INTERVAL = CHANNEL_SCHEDULER_INTERVAL
     VIP_SCHEDULER_INTERVAL = VIP_SCHEDULER_INTERVAL


### PR DESCRIPTION
## Summary
- expose trivia router through `mybot.routers`
- add automatic trivia scheduler
- wire scheduler and router into the bot
- allow environment variables `CANAL_KINKYS_ID` and `CANAL_DIVAN_ID`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m py_compile mybot/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686088cd7e0c83298e26a93470b212c2