### PR TITLE
Integrate trivia router with mission system

### DIFF
--- a/mybot/quests/trivia_quest_integration.py
+++ b/mybot/quests/trivia_quest_integration.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from sqlalchemy.ext.asyncio import AsyncSession
+from database.models import User
+
+from services.mission_service import MissionService
+
+logger = logging.getLogger(__name__)
+
+
+class TriviaQuestIntegration:
+    """Integrates trivia results with the mission system."""
+
+    @staticmethod
+    async def check_trivia_missions(
+        user_id: int,
+        result: dict,
+        session: AsyncSession,
+        bot=None,
+    ) -> list[dict]:
+        """Update trivia mission progress and return newly completed missions."""
+        mission_service = MissionService(session)
+        completed: list[dict] = []
+
+        try:
+            # Generic progress for answering a trivia question
+            await mission_service.update_progress(user_id, "trivia", bot=bot)
+            if result.get("is_correct"):
+                await mission_service.update_progress(
+                    user_id, "trivia_correct", bot=bot
+                )
+        except Exception as exc:
+            logger.exception("Error updating trivia mission progress: %s", exc)
+            return completed
+
+        # Fetch active missions to see which ones are now completed
+        missions = await mission_service.get_active_missions(user_id=user_id)
+        user = await session.get(User, user_id)
+        for mission in missions:
+            is_completed, _ = await mission_service.check_mission_completion_status(
+                user, mission
+            )
+            if is_completed:
+                completed.append(
+                    {
+                        "description": mission.description or mission.name,
+                        "reward_points": mission.reward_points,
+                        "reward_lorepiece": mission.unlocks_lore_piece_code,
+                    }
+                )
+        return completed
+
+    @staticmethod
+    async def trigger_special_missions(
+        user_id: int,
+        stats: dict,
+        session: AsyncSession,
+        bot=None,
+    ) -> list[dict]:
+        """Trigger special missions based on user trivia stats."""
+        mission_service = MissionService(session)
+        completed: list[dict] = []
+
+        try:
+            streak = stats.get("streak", 0)
+            if streak >= 10:
+                success, mission = await mission_service.complete_mission(
+                    user_id, "trivia_streak_10", bot=bot
+                )
+                if success and mission:
+                    completed.append(
+                        {
+                            "description": mission.description or mission.name,
+                            "reward_points": mission.reward_points,
+                            "reward_lorepiece": mission.unlocks_lore_piece_code,
+                        }
+                    )
+        except Exception as exc:
+            logger.exception("Error triggering special trivia missions: %s", exc)
+
+        return completed

--- a/mybot/trivia_router.py
+++ b/mybot/trivia_router.py
@@ -5,6 +5,7 @@ from aiogram import Router, F, Bot
 from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from mybot.quests.trivia_quest_integration import TriviaQuestIntegration
 from services.trivia_service import TriviaService
 from utils.user_roles import get_user_role, is_admin
 
@@ -61,6 +62,10 @@ async def trivia_response(callback: CallbackQuery, session: AsyncSession, bot: B
     service = TriviaService(session)
     result = await service.save_trivia_answer(user_id, question_id, option, response_time)
 
+    missions_completed = await TriviaQuestIntegration.check_trivia_missions(user_id, result, session, bot)
+    stats = await service.get_user_trivia_stats(user_id)
+    special_missions = await TriviaQuestIntegration.trigger_special_missions(user_id, stats, session, bot)
+
     if result["is_correct"]:
         text = (
             f"✅ ¡Correcto! Has ganado {result['points']} puntos.\n"
@@ -83,9 +88,13 @@ async def trivia_response(callback: CallbackQuery, session: AsyncSession, bot: B
     )
 
     await callback.message.edit_text(text)
+
+    for mission in missions_completed + special_missions:
+        await callback.message.answer(
+            f"🎯 *Misión completada:* {mission['description']}\n"
+            f"🏆 *Recompensa:* {mission['reward_points']} puntos y {mission['reward_lorepiece']}"
+        )
     await callback.answer()
-
-
 @router.message(F.text == "📊 Mis Estadísticas de Trivia")
 async def show_stats(message: Message, session: AsyncSession):
     service = TriviaService(session)


### PR DESCRIPTION
## Summary
- add quest integration module for trivia missions
- invoke integration hooks after saving trivia answer
- send completion messages when missions are triggered

## Testing
- `python -m py_compile mybot/trivia_router.py mybot/quests/trivia_quest_integration.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68608eff35008329b1dee71d2d4a6fb4