### PR TITLE
Fix trivia_router import

### DIFF
--- a/mybot/routers/__init__.py
+++ b/mybot/routers/__init__.py
@@ -1,2 +1,6 @@
 # No coloques mybot como módulo, es la raíz del proyecto
-from ..trivia_router import router as trivia_router
+# Cuando se ejecuta ``bot.py`` directamente, los imports relativos fallan
+# porque ``mybot`` no se trata como un paquete. Usamos una importación
+# absoluta para asegurar compatibilidad sin importar cómo se ejecute el
+# proyecto.
+from trivia_router import router as trivia_router


### PR DESCRIPTION
## Summary
- fix relative import in `mybot/routers/__init__.py` that was causing `ImportError`
- use absolute import so running `bot.py` directly works

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686094d24c708329a20ff5fef3478840