### PR TITLE
Fix trivia router import

### DIFF
--- a/mybot/routers/__init__.py
+++ b/mybot/routers/__init__.py
@@ -1,2 +1,5 @@
 # No coloques mybot como módulo, es la raíz del proyecto
-from ..trivia_router import router as trivia_router
+# Importamos el router de trivia usando una ruta absoluta para evitar
+# problemas de importación cuando "routers" es tratado como un módulo de
+# primer nivel.
+from trivia_router import router as trivia_router


### PR DESCRIPTION
## Summary
- avoid relative import in `routers/__init__.py` which raised `attempted relative import beyond top-level package`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_6860ad8406188329959d0ab53b4eb8f9