### PR TITLE
Implement trivia game module

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -28,6 +28,7 @@ from database.setup import init_db, get_session
 
 from handlers import start, free_user
 from handlers import daily_gift, minigames
+from handlers import trivia as trivia_handlers
 from handlers.channel_access import router as channel_access_router
 from handlers.user import start_token
 from handlers.vip import menu as vip
@@ -117,6 +118,7 @@ async def main() -> None:
     dp.include_router(reaction_callback_router)
     dp.include_router(daily_gift.router)
     dp.include_router(minigames.router)
+    dp.include_router(trivia_handlers.router)
     dp.include_router(free_user.router)
     dp.include_router(lore_router)
     dp.include_router(combinar_pistas.router)

--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -446,6 +446,29 @@ class UserLorePiece(AsyncAttrs, Base):
     )
 
 
+class TriviaQuestion(AsyncAttrs, Base):
+    __tablename__ = "trivia_questions"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    question = Column(String, nullable=False)
+    options = Column(JSON, nullable=False)
+    correct_option = Column(String, nullable=False)
+    points = Column(Integer, default=0)
+    mission_required = Column(String, nullable=True)
+    exclusive_content = Column(Boolean, default=False)
+    unlocks = Column(String, nullable=True)
+
+
+class TriviaResult(AsyncAttrs, Base):
+    __tablename__ = "trivia_results"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(BigInteger, nullable=False)
+    question_id = Column(Integer, ForeignKey("trivia_questions.id"))
+    is_correct = Column(Boolean, default=False)
+    timestamp = Column(DateTime, default=func.now())
+
+
 
 # Funciones para manejar el estado del menú del usuario
 async def get_user_menu_state(session, user_id: int) -> str:

--- a/mybot/handlers/trivia.py
+++ b/mybot/handlers/trivia.py
@@ -1,0 +1,66 @@
+from aiogram import Router, F, Bot
+from aiogram.types import Message, CallbackQuery
+from sqlalchemy.ext.asyncio import AsyncSession
+from database.models import TriviaQuestion
+
+from utils.messages import BOT_MESSAGES
+from keyboards.trivia_kb import (
+    get_trivia_options_keyboard,
+    get_trivia_retry_keyboard,
+    get_generic_back_keyboard,
+)
+from services.trivia_service import TriviaService, parse_options_from_db
+
+router = Router()
+
+
+@router.message(F.text.regexp("^/trivia$"))
+async def command_trivia(message: Message, session: AsyncSession):
+    service = TriviaService(session)
+    question = await service.get_random_trivia_question(message.from_user.id)
+    if not question:
+        await message.answer(BOT_MESSAGES.get("trivia_no_questions", "No hay preguntas."))
+        return
+    options = parse_options_from_db(question.options)
+    kb = get_trivia_options_keyboard(question.id, options)
+    await message.answer(question.question, reply_markup=kb)
+
+
+@router.callback_query(F.data.startswith("trivia_answer:"))
+async def process_trivia_answer(callback: CallbackQuery, session: AsyncSession, bot: Bot):
+    _, qid, index = callback.data.split(":")
+    question = await session.get(TriviaQuestion, int(qid))
+    options = parse_options_from_db(question.options)
+    selected = options[int(index)] if int(index) < len(options) else None
+    is_correct = selected == question.correct_option
+    service = TriviaService(session)
+    if is_correct:
+        await service.record_trivia_result(callback.from_user.id, question.id, True)
+        await service.handle_correct_answer(callback.from_user.id, question, bot=bot)
+        await callback.message.edit_text(
+            BOT_MESSAGES.get("trivia_correct_answer", "¡Correcto!").format(points=question.points),
+            reply_markup=get_generic_back_keyboard(),
+        )
+    else:
+        await service.record_trivia_result(callback.from_user.id, question.id, False)
+        await callback.message.edit_text(
+            BOT_MESSAGES.get("trivia_wrong_answer", "Incorrecto"),
+            reply_markup=get_trivia_retry_keyboard(question.id),
+        )
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("trivia_retry:"))
+async def trivia_retry(callback: CallbackQuery, session: AsyncSession):
+    _, qid = callback.data.split(":")
+    question = await session.get(TriviaQuestion, int(qid))
+    options = parse_options_from_db(question.options)
+    kb = get_trivia_options_keyboard(question.id, options)
+    await callback.message.edit_text(question.question, reply_markup=kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "trivia_cancel")
+async def trivia_cancel(callback: CallbackQuery):
+    await callback.message.edit_text(BOT_MESSAGES.get("trivia_back", "Volver"))
+    await callback.answer()

--- a/mybot/keyboards/trivia_kb.py
+++ b/mybot/keyboards/trivia_kb.py
@@ -1,0 +1,25 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+
+
+def get_trivia_options_keyboard(question_id: int, options: list[str]) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    for idx, option in enumerate(options):
+        builder.button(text=option, callback_data=f"trivia_answer:{question_id}:{idx}")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_trivia_retry_keyboard(question_id: int) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="🔄 Intentar de nuevo", callback_data=f"trivia_retry:{question_id}")
+    builder.button(text="❌ Cancelar", callback_data="trivia_cancel")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def get_generic_back_keyboard(callback: str = "trivia_back") -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text="⬅️ Volver", callback_data=callback)
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/services/trivia_service.py
+++ b/mybot/services/trivia_service.py
@@ -1,0 +1,71 @@
+import random
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func
+from database.models import TriviaQuestion, TriviaResult
+from services.point_service import PointService
+from backpack import desbloquear_pista_narrativa
+
+
+def parse_options_from_db(options_field) -> list[str]:
+    if isinstance(options_field, list):
+        return options_field
+    if isinstance(options_field, str):
+        try:
+            import json
+            return json.loads(options_field)
+        except Exception:
+            return [opt.strip() for opt in options_field.split("|") if opt.strip()]
+    return []
+
+
+class TriviaService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_random_trivia_question(self, user_id: int) -> TriviaQuestion | None:
+        stmt = select(TriviaQuestion)
+        result = await self.session.execute(stmt)
+        questions = result.scalars().all()
+        if not questions:
+            return None
+        answered_stmt = select(TriviaResult.question_id).where(
+            TriviaResult.user_id == user_id, TriviaResult.is_correct == True
+        )
+        answered = await self.session.execute(answered_stmt)
+        answered_ids = {row[0] for row in answered.all()}
+        available = [q for q in questions if q.id not in answered_ids]
+        if not available:
+            return None
+        return random.choice(available)
+
+    async def record_trivia_result(self, user_id: int, question_id: int, is_correct: bool) -> TriviaResult:
+        result = TriviaResult(user_id=user_id, question_id=question_id, is_correct=is_correct)
+        self.session.add(result)
+        await self.session.commit()
+        await self.session.refresh(result)
+        return result
+
+    async def get_trivia_attempts(self, user_id: int, question_id: int) -> int:
+        stmt = select(func.count(TriviaResult.id)).where(
+            TriviaResult.user_id == user_id, TriviaResult.question_id == question_id
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one() or 0
+
+    async def check_if_trivia_answered_correctly(self, user_id: int, question_id: int) -> bool:
+        stmt = select(TriviaResult).where(
+            TriviaResult.user_id == user_id,
+            TriviaResult.question_id == question_id,
+            TriviaResult.is_correct == True,
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+
+    async def handle_correct_answer(self, user_id: int, question: TriviaQuestion, bot=None):
+        await PointService(self.session).add_points(user_id, question.points, bot=bot)
+        if question.unlocks:
+            await desbloquear_pista_narrativa(bot, user_id, question.unlocks, {"source": "trivia"})
+
+    async def handle_incorrect_answer(self, user_id: int, question_id: int):
+        await self.record_trivia_result(user_id, question_id, False)
+

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -174,12 +174,23 @@ MISSION_MESSAGES = {
     "view_all_missions_button_text": "📋 Ver Todas las Misiones",
 }
 
+# --- TRIVIA MESSAGES ---
+TRIVIA_MESSAGES = {
+    "trivia_intro": "🧠 *Ponte a prueba con esta trivia!*",
+    "trivia_correct_answer": "🎉 ¡Respuesta correcta! Ganaste {points} puntos.",
+    "trivia_wrong_answer": "❌ Respuesta incorrecta.",
+    "trivia_retry": "¿Quieres intentarlo de nuevo?",
+    "trivia_no_questions": "No hay preguntas disponibles en este momento.",
+    "trivia_back": "⬅️ Volver",
+}
+
 # Aggregate all messages for backward compatibility
 BOT_MESSAGES = {
     **BUTLER_MESSAGES,
     **KINKY_MESSAGES,
     **MENU_TEXTS,
     **MISSION_MESSAGES,
+    **TRIVIA_MESSAGES,
 }
 
 # Badge descriptions


### PR DESCRIPTION
## Summary
- add `TriviaQuestion` and `TriviaResult` models
- centralize trivia messages
- implement trivia keyboards
- add trivia service for fetching questions and recording results
- provide handlers for new `/trivia` command
- register trivia router in the bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6860bb7c8ec48329b5fd955351d2bd0d