### PR TITLE
Add storyboard player integration

### DIFF
--- a/mybot/handlers/free_channel_admin.py
+++ b/mybot/handlers/free_channel_admin.py
@@ -422,3 +422,9 @@ async def cleanup_old_requests(callback: CallbackQuery, session: AsyncSession):
     
     # Actualizar el menú
     await free_channel_admin_menu(callback, session)
+
+
+@router.callback_query(F.data == "manage_storyboard")
+async def open_storyboard_menu(callback: CallbackQuery):
+    from handlers.storyboard_admin import show_storyboard_menu
+    await show_storyboard_menu(callback.message)

--- a/mybot/handlers/storyboard_player.py
+++ b/mybot/handlers/storyboard_player.py
@@ -1,0 +1,40 @@
+from aiogram import Router, F
+from aiogram.types import Message, CallbackQuery
+from aiogram.filters import Command
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from services.storyboard_service import StoryboardService
+
+router = Router()
+
+user_story_progress = {}
+
+@router.message(Command("play_story"))
+async def start_story(message: Message):
+    scene_id = "intro"  # Escena inicial por defecto
+    user_story_progress[message.from_user.id] = {"scene_id": scene_id, "order": 1}
+    await send_next_dialogue(message.chat.id, message.from_user.id)
+
+async def send_next_dialogue(chat_id, user_id):
+    progress = user_story_progress.get(user_id)
+    if not progress:
+        return
+
+    scene_id = progress["scene_id"]
+    order = progress["order"]
+
+    dialogues = await StoryboardService.get_scene_dialogues(scene_id)
+    if order > len(dialogues):
+        return
+
+    dialogue = dialogues[order - 1]
+    text = f"*{dialogue.character}*\n{dialogue.dialogue}"
+
+    if dialogue.media_type == 'text':
+        keyboard = InlineKeyboardBuilder().button(text="Siguiente", callback_data="next_dialogue").as_markup()
+        await router.bot.send_message(chat_id, text, parse_mode="Markdown", reply_markup=keyboard)
+
+    progress["order"] += 1
+
+@router.callback_query(F.data == "next_dialogue")
+async def handle_next_dialogue(callback: CallbackQuery):
+    await send_next_dialogue(callback.message.chat.id, callback.from_user.id)

--- a/mybot/keyboards/free_channel_admin_kb.py
+++ b/mybot/keyboards/free_channel_admin_kb.py
@@ -19,7 +19,8 @@ def get_free_channel_admin_kb(channel_configured: bool = False) -> InlineKeyboar
         builder.button(text="📝 Configurar Reacciones Free", callback_data="free_config_reactions")
     else:
         builder.button(text="⚙️ Configurar Canal Gratuito", callback_data="configure_free_channel")
-    
+
+    builder.button(text="🎮 Administrar Storyboard", callback_data="manage_storyboard")
     builder.button(text="🔙 Volver", callback_data="admin_main_menu")
     builder.adjust(1)
     return builder.as_markup()

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -191,6 +191,10 @@ BOT_MESSAGES = {
     **MENU_TEXTS,
     **MISSION_MESSAGES,
     **TRIVIA_MESSAGES,
+    "storyboard_admin": "🗂️ Storyboard Admin",
+    "new_scene_prompt": "Escribe el ID de la nueva escena:",
+    "scene_created": "✅ Escena '{scene_id}' creada.",
+    "available_scenes": "📚 Escenas disponibles:\n{scenes}",
 }
 
 # Badge descriptions


### PR DESCRIPTION
## Summary
- add storyboard player handler
- expose storyboard admin from free channel menu
- include button for storyboard admin
- centralize storyboard messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686156f3206083298dc9ae9851929dab