### PR TITLE
Add start message validation

### DIFF
--- a/mybot/handlers/admin/admin_config.py
+++ b/mybot/handlers/admin/admin_config.py
@@ -48,7 +48,22 @@ async def free_config_reactions(callback: CallbackQuery, state: FSMContext):
 @router.message(AdminConfigStates.waiting_for_reactions_input)
 async def process_reactions_input(message: Message, state: FSMContext):
     if not is_admin(message.from_user.id):
-        await menu_manager.send_temporary_message(message, "❌ Acceso Denegado.", auto_delete_seconds=3)
+        start_message = "❌ Acceso Denegado."
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            await state.clear()
+            return
+        await menu_manager.send_temporary_message(
+            message,
+            start_message,
+            auto_delete_seconds=3,
+        )
         await state.clear()
         return
 
@@ -93,7 +108,22 @@ async def process_reactions_input(message: Message, state: FSMContext):
 @router.message(AdminConfigStates.waiting_for_points_input)
 async def process_points_input(message: Message, state: FSMContext):
     if not is_admin(message.from_user.id):
-        await menu_manager.send_temporary_message(message, "❌ Acceso Denegado.", auto_delete_seconds=3)
+        start_message = "❌ Acceso Denegado."
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            await state.clear()
+            return
+        await menu_manager.send_temporary_message(
+            message,
+            start_message,
+            auto_delete_seconds=3,
+        )
         await state.clear()
         return
 

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -68,10 +68,20 @@ async def admin_menu(message: Message, session: AsyncSession, user_id: int | Non
     """Enhanced admin menu command."""
     uid = user_id if user_id is not None else message.from_user.id
     if not is_admin(uid):
+        start_message = "❌ **Acceso Denegado**\n\nNo tienes permisos de administrador."
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            return
         await menu_manager.send_temporary_message(
             message,
-            "❌ **Acceso Denegado**\n\nNo tienes permisos de administrador.",
-            auto_delete_seconds=5
+            start_message,
+            auto_delete_seconds=5,
         )
         return
     
@@ -80,10 +90,20 @@ async def admin_menu(message: Message, session: AsyncSession, user_id: int | Non
         await menu_manager.show_menu(message, text, keyboard, session, "admin_main")
     except Exception as e:
         logger.error(f"Error showing admin menu for user {uid}: {e}")
+        start_message = "❌ **Error Temporal**\n\nNo se pudo cargar el panel de administración."
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            return
         await menu_manager.send_temporary_message(
             message,
-            "❌ **Error Temporal**\n\nNo se pudo cargar el panel de administración.",
-            auto_delete_seconds=5
+            start_message,
+            auto_delete_seconds=5,
         )
 
 @router.callback_query(F.data == "admin_stats")
@@ -264,10 +284,20 @@ async def admin_bot_config(callback: CallbackQuery, session: AsyncSession):
 async def admin_generate_token_cmd(message: Message, session: AsyncSession, bot: Bot):
     """Enhanced token generation command."""
     if not is_admin(message.from_user.id):
+        start_message = "❌ **Acceso Denegado**\n\nNo tienes permisos de administrador."
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            return
         await menu_manager.send_temporary_message(
             message,
-            "❌ **Acceso Denegado**\n\nNo tienes permisos de administrador.",
-            auto_delete_seconds=5
+            start_message,
+            auto_delete_seconds=5,
         )
         return
     
@@ -276,11 +306,23 @@ async def admin_generate_token_cmd(message: Message, session: AsyncSession, bot:
         tariffs = result.scalars().all()
         
         if not tariffs:
+            start_message = (
+                "❌ **Sin Tarifas Configuradas**\n\n"
+                "Primero debes configurar las tarifas VIP desde el panel de administración."
+            )
+            if not start_message.strip():
+                import logging
+                logging.error(
+                    f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+                )
+                await message.answer(
+                    "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+                )
+                return
             await menu_manager.send_temporary_message(
                 message,
-                "❌ **Sin Tarifas Configuradas**\n\n"
-                "Primero debes configurar las tarifas VIP desde el panel de administración.",
-                auto_delete_seconds=8
+                start_message,
+                auto_delete_seconds=8,
             )
             return
         
@@ -296,10 +338,20 @@ async def admin_generate_token_cmd(message: Message, session: AsyncSession, bot:
         )
     except Exception as e:
         logger.error(f"Error in token generation command: {e}")
+        start_message = "❌ **Error Temporal**\n\nNo se pudo cargar las tarifas."
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            return
         await menu_manager.send_temporary_message(
             message,
-            "❌ **Error Temporal**\n\nNo se pudo cargar las tarifas.",
-            auto_delete_seconds=5
+            start_message,
+            auto_delete_seconds=5,
         )
 
 @router.callback_query(F.data.startswith("generate_token_"))

--- a/mybot/handlers/free_channel_admin.py
+++ b/mybot/handlers/free_channel_admin.py
@@ -100,10 +100,20 @@ async def process_free_channel_id(message: Message, state: FSMContext, session: 
         try:
             channel_id = int(message.text.strip())
         except ValueError:
+            start_message = "❌ **ID Inválido**\n\nPor favor, reenvía un mensaje del canal o ingresa un ID válido."
+            if not start_message.strip():
+                import logging
+                logging.error(
+                    f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+                )
+                await message.answer(
+                    "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+                )
+                return
             await menu_manager.send_temporary_message(
                 message,
-                "❌ **ID Inválido**\n\nPor favor, reenvía un mensaje del canal o ingresa un ID válido.",
-                auto_delete_seconds=5
+                start_message,
+                auto_delete_seconds=5,
             )
             return
     
@@ -124,10 +134,20 @@ async def process_free_channel_id(message: Message, state: FSMContext, session: 
             "admin_free_channel"
         )
     else:
+        start_message = "❌ **Error de Configuración**\n\nNo se pudo configurar el canal. Intenta nuevamente."
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            return
         await menu_manager.send_temporary_message(
             message,
-            "❌ **Error de Configuración**\n\nNo se pudo configurar el canal. Intenta nuevamente.",
-            auto_delete_seconds=5
+            start_message,
+            auto_delete_seconds=5,
         )
     
     await state.clear()

--- a/mybot/handlers/free_user.py
+++ b/mybot/handlers/free_user.py
@@ -130,9 +130,20 @@ async def cb_vip_explore_interest(callback: CallbackQuery, session: AsyncSession
         f"Interés en VIP de {user.first_name} (@{user.username or user.id})"
     )
     await notify_admins(callback.bot, notify_text)
+    start_message = BOT_MESSAGES.get("VIP_INTEREST_REPLY")
+    if not start_message.strip():
+        import logging
+        logging.error(
+            f"Intento de iniciar flujo con mensaje vacío para el usuario {callback.from_user.id}"
+        )
+        await callback.message.answer(
+            "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+        )
+        await callback.answer()
+        return
     await menu_manager.send_temporary_message(
         callback.message,
-        BOT_MESSAGES.get("VIP_INTEREST_REPLY"),
+        start_message,
         auto_delete_seconds=8,
     )
     await callback.answer()
@@ -149,9 +160,20 @@ async def cb_pack_details(callback: CallbackQuery, session: AsyncSession):
             f"(@{user.username or user.id})"
         )
         await notify_admins(callback.bot, notify_text)
+        start_message = BOT_MESSAGES.get("PACK_INTEREST_REPLY")
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {callback.from_user.id}"
+            )
+            await callback.message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            await callback.answer()
+            return
         await menu_manager.send_temporary_message(
             callback.message,
-            BOT_MESSAGES.get("PACK_INTEREST_REPLY"),
+            start_message,
             auto_delete_seconds=8,
         )
         await callback.answer()

--- a/mybot/handlers/setup.py
+++ b/mybot/handlers/setup.py
@@ -45,10 +45,20 @@ class SetupStates(StatesGroup):
 async def start_setup(message: Message, session: AsyncSession):
     """Start the initial setup process for new admins."""
     if not is_admin(message.from_user.id):
+        start_message = "❌ **Acceso Denegado**\n\nSolo los administradores pueden acceder a la configuración inicial."
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            return
         await menu_manager.send_temporary_message(
             message,
-            "❌ **Acceso Denegado**\n\nSolo los administradores pueden acceder a la configuración inicial.",
-            auto_delete_seconds=5
+            start_message,
+            auto_delete_seconds=5,
         )
         return
     
@@ -58,10 +68,20 @@ async def start_setup(message: Message, session: AsyncSession):
     init_result = await tenant_service.initialize_tenant(message.from_user.id)
     
     if not init_result["success"]:
+        start_message = f"❌ **Error de Inicialización**\n\n{init_result['error']}"
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            return
         await menu_manager.send_temporary_message(
             message,
-            f"❌ **Error de Inicialización**\n\n{init_result['error']}",
-            auto_delete_seconds=10
+            start_message,
+            auto_delete_seconds=10,
         )
         return
     
@@ -171,10 +191,20 @@ async def process_vip_channel(message: Message, state: FSMContext, session: Asyn
                 pass # Se manejará como ID inválido
         
         if not channel_id:
+            start_message = "❌ **ID Inválido**\n\nPor favor, reenvía un mensaje del canal o ingresa un ID válido."
+            if not start_message.strip():
+                import logging
+                logging.error(
+                    f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+                )
+                await message.answer(
+                    "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+                )
+                return await state.set_state(SetupStates.waiting_for_vip_channel)
             await menu_manager.send_temporary_message(
                 message,
-                "❌ **ID Inválido**\n\nPor favor, reenvía un mensaje del canal o ingresa un ID válido.",
-                auto_delete_seconds=5
+                start_message,
+                auto_delete_seconds=5,
             )
             return await state.set_state(SetupStates.waiting_for_vip_channel) # Volver a esperar
     
@@ -219,10 +249,20 @@ async def process_free_channel(message: Message, state: FSMContext, session: Asy
                 pass
         
         if not channel_id:
+            start_message = "❌ **ID Inválido**\n\nPor favor, reenvía un mensaje del canal o ingresa un ID válido."
+            if not start_message.strip():
+                import logging
+                logging.error(
+                    f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+                )
+                await message.answer(
+                    "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+                )
+                return await state.set_state(SetupStates.waiting_for_free_channel)
             await menu_manager.send_temporary_message(
                 message,
-                "❌ **ID Inválido**\n\nPor favor, reenvía un mensaje del canal o ingresa un ID válido.",
-                auto_delete_seconds=5
+                start_message,
+                auto_delete_seconds=5,
             )
             return await state.set_state(SetupStates.waiting_for_free_channel) # Volver a esperar
     
@@ -387,11 +427,24 @@ async def process_manual_channel_id(message: Message, state: FSMContext, session
         await state.set_state(SetupStates.waiting_for_channel_confirmation)
         
     except ValueError:
+        start_message = (
+            "❌ **ID Inválido**\n\nPor favor, ingresa un ID numérico válido para el canal. "
+            "Debe empezar con `-100`."
+        )
+        if not start_message.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            await state.set_state(SetupStates.waiting_for_manual_channel_id)
+            return
         await menu_manager.send_temporary_message(
             message,
-            "❌ **ID Inválido**\n\nPor favor, ingresa un ID numérico válido para el canal. "
-            "Debe empezar con `-100`.",
-            auto_delete_seconds=7
+            start_message,
+            auto_delete_seconds=7,
         )
         await state.set_state(SetupStates.waiting_for_manual_channel_id) # Volver a esperar
     

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -72,11 +72,26 @@ async def cmd_start(message: Message, session: AsyncSession):
         # Esto es importante para que el panel de administración funcione correctamente
         init_result = await tenant_service.initialize_tenant(user_id)
         if not init_result["success"]:
-            logger.error(f"Failed to initialize tenant for admin {user_id}: {init_result['error']}")
+            logger.error(
+                f"Failed to initialize tenant for admin {user_id}: {init_result['error']}"
+            )
+            start_message = (
+                "❌ **Error Crítico**\n\n"
+                "No se pudo inicializar la configuración de administrador. Por favor, contacta a soporte."
+            )
+            if not start_message.strip():
+                import logging
+                logging.error(
+                    f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
+                )
+                await message.answer(
+                    "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+                )
+                return
             await menu_manager.send_temporary_message(
                 message,
-                f"❌ **Error Crítico**\n\nNo se pudo inicializar la configuración de administrador. Por favor, contacta a soporte.",
-                auto_delete_seconds=10
+                start_message,
+                auto_delete_seconds=10,
             )
             return
 
@@ -97,20 +112,23 @@ async def cmd_start(message: Message, session: AsyncSession):
         )
         # Display the reply keyboard without cluttering the chat
         start_message = "​"
-        if start_message.strip():
-            await menu_manager.send_temporary_message(
-                message,
-                start_message,
-                keyboard=main_menu_keyboard,
-                auto_delete_seconds=0,
-                parse_mode="Markdown",
-            )
-        else:
+        if not start_message.strip():
             import logging
             logging.error(
                 f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
             )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
             return
+
+        await menu_manager.send_temporary_message(
+            message,
+            start_message,
+            keyboard=main_menu_keyboard,
+            auto_delete_seconds=0,
+            parse_mode="Markdown",
+        )
         return # Terminar aquí para el flujo de administración
     
     # Lógica para usuarios no-administradores (VIP, Free)
@@ -139,20 +157,23 @@ async def cmd_start(message: Message, session: AsyncSession):
         )
         # Show the reply keyboard silently so it coexists with the inline menu
         start_message = "​"
-        if start_message.strip():
-            await menu_manager.send_temporary_message(
-                message,
-                start_message,
-                keyboard=main_menu_keyboard,
-                auto_delete_seconds=0,
-                parse_mode="Markdown",
-            )
-        else:
+        if not start_message.strip():
             import logging
             logging.error(
                 f"Intento de iniciar flujo con mensaje vacío para el usuario {message.from_user.id}"
             )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
             return
+
+        await menu_manager.send_temporary_message(
+            message,
+            start_message,
+            keyboard=main_menu_keyboard,
+            auto_delete_seconds=0,
+            parse_mode="Markdown",
+        )
 
     except Exception as e:
         logger.error(f"Error in start command for user {user_id}: {e}")


### PR DESCRIPTION
## Summary
- log and stop when a menu start message is empty before sending
- apply empty-text validation in several handlers

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686162d8e3b48329a6082756cdc26130