### PR TITLE
Add dialogue validation and empty text checks

### DIFF
--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -102,6 +102,16 @@ async def cmd_start(message: Message, session: AsyncSession):
         welcome_prefix = "👑 **¡Bienvenido, Administrador!**\n\n"
         text = welcome_prefix + text.split('\n\n', 1)[-1] # Mantiene el texto del menú, pero reemplaza el saludo inicial
 
+        if not text.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con texto vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            return
+
         await menu_manager.show_menu(
             message,
             text,
@@ -139,14 +149,24 @@ async def cmd_start(message: Message, session: AsyncSession):
             welcome_prefix = "🌟 **¡Bienvenido!**\n\n"
             if "suscripción vip" in text.lower() or "experiencia premium" in text.lower():
                 welcome_prefix = "✨ **¡Bienvenido, Miembro VIP!**\n\n"
-            
+
             text = welcome_prefix + text
         else:
             if "suscripción vip" in text.lower() or "experiencia premium" in text.lower():
                 text = "✨ **Bienvenido de vuelta**\n\n" + text.split('\n\n', 1)[-1]
             else:
                 text = "🌟 **¡Hola de nuevo!**\n\n" + text.split('\n\n', 1)[-1]
-        
+
+        if not text.strip():
+            import logging
+            logging.error(
+                f"Intento de iniciar flujo con texto vacío para el usuario {message.from_user.id}"
+            )
+            await message.answer(
+                "Ocurrió un error al iniciar el flujo. Por favor intenta más tarde."
+            )
+            return
+
         await menu_manager.show_menu(
             message,
             text,

--- a/mybot/handlers/storyboard_player.py
+++ b/mybot/handlers/storyboard_player.py
@@ -17,6 +17,7 @@ async def start_story(message: Message):
 async def send_next_dialogue(chat_id, user_id):
     progress = user_story_progress.get(user_id)
     if not progress:
+        await router.bot.send_message(chat_id, "No se encontró el progreso del usuario.")
         return
 
     scene_id = progress["scene_id"]
@@ -24,14 +25,14 @@ async def send_next_dialogue(chat_id, user_id):
 
     dialogues = await StoryboardService.get_scene_dialogues(scene_id)
 
-    # Validación 1: Si no hay diálogos
+    # Validación 1: Si la consulta no devolvió ningún diálogo
     if not dialogues:
-        await router.bot.send_message(chat_id, "Esta escena no tiene diálogos disponibles.")
+        await router.bot.send_message(chat_id, "Esta escena no tiene diálogos disponibles. Contacta al administrador.")
         return
 
-    # Validación 2: Si se pasaron del límite
+    # Validación 2: Si el orden supera la cantidad de diálogos
     if order > len(dialogues):
-        await router.bot.send_message(chat_id, "Has llegado al final de la escena.")
+        await router.bot.send_message(chat_id, "Has llegado al final de esta escena.")
         return
 
     dialogue = dialogues[order - 1]


### PR DESCRIPTION
## Summary
- enhance dialogue player with validations and user feedback
- avoid sending empty start flow text
- keep check that menu_manager doesn't send empty messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616a798ccc8329a053656f7207684d