### PR TITLE
Include storyboard routers

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -47,6 +47,8 @@ from handlers import setup as setup_handlers # ¡IMPORTACIÓN CLAVE!
 
 from handlers.free_channel_admin import router as free_channel_admin_router
 from handlers.publication_test import router as publication_test_router
+from handlers.storyboard_admin import router as storyboard_admin_router
+from handlers.storyboard_player import router as storyboard_player_router
 import combinar_pistas
 from backpack import router as backpack_router
 
@@ -124,6 +126,8 @@ async def main() -> None:
     dp.include_router(trivia_handlers.router)
     dp.include_router(free_user.router)
     dp.include_router(lore_router)
+    dp.include_router(storyboard_admin_router)
+    dp.include_router(storyboard_player_router)
     dp.include_router(combinar_pistas.router)
     dp.include_router(channel_access_router)
 

--- a/mybot/handlers/__init__.py
+++ b/mybot/handlers/__init__.py
@@ -1,0 +1,10 @@
+"""Expose storyboard related routers for easy import."""
+
+from .storyboard_admin import router as storyboard_admin_router
+from .storyboard_player import router as storyboard_player_router
+
+__all__ = [
+    "storyboard_admin_router",
+    "storyboard_player_router",
+]
+


### PR DESCRIPTION
## Summary
- expose storyboard routers from handlers package
- include storyboard routers in Dispatcher config

## Testing
- `python -m py_compile mybot/bot.py mybot/handlers/__init__.py mybot/handlers/storyboard_admin.py mybot/handlers/storyboard_player.py`

------
https://chatgpt.com/codex/tasks/task_e_68616db4e1bc8329b3fd4c321dc85b7d