### PR TITLE
Fix dialogue ID validation

### DIFF
--- a/mybot/handlers/storyboard_admin.py
+++ b/mybot/handlers/storyboard_admin.py
@@ -97,10 +97,18 @@ async def start_edit_dialogue(callback: CallbackQuery, state: FSMContext):
 
 @router.message(StateFilter(StoryboardStates.waiting_dialogue_id_edit), F.text)
 async def receive_dialogue_id_for_edit(message: Message, state: FSMContext):
-    dialogue_id = int(message.text)
-    await state.update_data(dialogue_id=dialogue_id)
-    await message.answer("✏️ Ingresa el nuevo texto del diálogo:")
-    await state.set_state(StoryboardStates.waiting_dialogue_text)
+    # Ignorar comandos que puedan enviarse accidentalmente en este estado
+    if message.text.startswith("/"):
+        return
+
+    try:
+        dialogue_id = int(message.text)
+        await state.update_data(dialogue_id=dialogue_id)
+        await message.answer("✏️ Ingresa el nuevo texto del diálogo:")
+        await state.set_state(StoryboardStates.waiting_dialogue_text)
+    except ValueError:
+        # Informar al usuario si no se proporciona un número válido
+        await message.answer("❌ Por favor, ingresa solo números.")
 
 @router.message(StateFilter(StoryboardStates.waiting_dialogue_text), F.text)
 async def edit_dialogue_text(message: Message, state: FSMContext):


### PR DESCRIPTION
## Summary
- improve validation when user edits dialogues

## Testing
- `pytest -q` *(fails: BOT_TOKEN environment variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_686175ef3374832988d2785f48450318