### PR TITLE
Add admin SQL update command

### DIFF
--- a/mybot/handlers/admin_commands.py
+++ b/mybot/handlers/admin_commands.py
@@ -1,0 +1,47 @@
+from aiogram.fsm.context import FSMContext
+from aiogram.filters import Command
+from aiogram import Router, F
+from aiogram.types import Message, CallbackQuery, FSInputFile, Document
+from utils.admin_state import DatabaseUpdateStates
+from utils.menu_manager import menu_manager
+from sqlalchemy.ext.asyncio import create_async_engine
+from utils.config import Config
+import os
+
+router = Router()
+
+@router.message(Command("update_database"))
+async def start_database_update(message: Message, state: FSMContext):
+    if not await menu_manager.is_admin(message.from_user.id):
+        await message.answer("\u26D4 No tienes permiso para usar este comando.")
+        return
+
+    await message.answer("\U0001F4C2 Por favor, envía el archivo SQL que deseas ejecutar.")
+    await state.set_state(DatabaseUpdateStates.waiting_for_sql)
+
+@router.message(F.document, state=DatabaseUpdateStates.waiting_for_sql)
+async def process_sql_file(message: Message, state: FSMContext):
+    document: Document = message.document
+    if not document.file_name.endswith('.sql'):
+        await message.answer("\u274C El archivo debe tener extensión .sql.")
+        return
+
+    file = await message.bot.get_file(document.file_id)
+    file_path = f"temp/{document.file_name}"
+    await message.bot.download_file(file.file_path, destination=file_path)
+
+    try:
+        await execute_sql_file(file_path)
+        await message.answer("\u2705 Base de datos actualizada correctamente.")
+    except Exception as e:
+        await message.answer(f"\u274C Error al ejecutar el archivo SQL: {str(e)}")
+    finally:
+        os.remove(file_path)
+        await state.clear()
+
+async def execute_sql_file(file_path):
+    engine = create_async_engine(Config.DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        with open(file_path, 'r', encoding='utf-8') as file:
+            sql_commands = file.read()
+        await conn.execute(sql_commands)

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -203,3 +203,6 @@ class StoryboardStates(StatesGroup):
     waiting_dialogue_id_edit = State()
     waiting_dialogue_id_delete = State()
     waiting_for_json = State()
+
+class DatabaseUpdateStates(StatesGroup):
+    waiting_for_sql = State()

--- a/mybot/utils/menu_manager.py
+++ b/mybot/utils/menu_manager.py
@@ -9,6 +9,7 @@ from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup
 from aiogram.exceptions import TelegramBadRequest, TelegramAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import User, set_user_menu_state
+from .config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,10 @@ class MenuManager:
         self._temp_messages: Dict[int, Tuple[int, int, float]] = {}  # user_id -> (chat_id, message_id, expire_time)
         # Navigation history for back button functionality
         self._nav_history: Dict[int, list] = {}  # user_id -> [menu_states]
+
+    async def is_admin(self, user_id: int) -> bool:
+        """Check if the given user ID matches the configured admin ID."""
+        return user_id == Config.ADMIN_ID
     
     async def show_menu(
         self, 


### PR DESCRIPTION
## Summary
- create `admin_commands` handler to process uploaded SQL files
- track SQL FSM state via `DatabaseUpdateStates`
- implement helper `is_admin` method in `menu_manager`

## Testing
- `pip install -r mybot/requirements.txt`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a2bb80808329b0928f30461fcb70