### PR TITLE
Implement trivia gamification

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -44,6 +44,7 @@ from handlers import setup as setup_handlers # ¡IMPORTACIÓN CLAVE!
 
 from handlers.free_channel_admin import router as free_channel_admin_router
 from handlers.publication_test import router as publication_test_router
+from handlers.trivia import router as trivia_router
 import combinar_pistas
 from backpack import router as backpack_router
 
@@ -117,6 +118,7 @@ async def main() -> None:
     dp.include_router(reaction_callback_router)
     dp.include_router(daily_gift.router)
     dp.include_router(minigames.router)
+    dp.include_router(trivia_router)
     dp.include_router(free_user.router)
     dp.include_router(lore_router)
     dp.include_router(combinar_pistas.router)

--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -446,6 +446,38 @@ class UserLorePiece(AsyncAttrs, Base):
     )
 
 
+class Trivia(AsyncAttrs, Base):
+    """Trivia questions for gamification."""
+
+    __tablename__ = "trivia"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    trigger_code = Column(String, unique=True, nullable=False)
+    question = Column(Text, nullable=False)
+    options = Column(JSON, nullable=False)  # list of option strings
+    correct_index = Column(Integer, nullable=False)
+    reward_points = Column(Integer, default=0)
+    unlocks_lore_piece_code = Column(String, nullable=True)
+    level_increment = Column(Integer, default=0)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=func.now())
+
+
+class TriviaResult(AsyncAttrs, Base):
+    """Stores results of trivia answers per user."""
+
+    __tablename__ = "trivia_results"
+
+    user_id = Column(BigInteger, ForeignKey("users.id"), primary_key=True)
+    trivia_id = Column(Integer, ForeignKey("trivia.id"), primary_key=True)
+    is_correct = Column(Boolean, nullable=False)
+    answered_at = Column(DateTime, default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "trivia_id", name="uix_trivia_result"),
+    )
+
+
 
 # Funciones para manejar el estado del menú del usuario
 async def get_user_menu_state(session, user_id: int) -> str:

--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -7,6 +7,7 @@ from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
 from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
+from .trivia_admin import router as trivia_admin_router
 
 __all__ = [
     "admin_router",
@@ -18,4 +19,5 @@ __all__ = [
     "game_admin_router",
     "event_admin_router",
     "admin_config_router",
+    "trivia_admin_router",
 ]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -33,6 +33,7 @@ from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
 from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
+from .trivia_admin import router as trivia_admin_router
 
 router.include_router(vip_router)
 router.include_router(free_router)
@@ -42,6 +43,7 @@ router.include_router(subscription_plans_router)
 router.include_router(game_admin_router)
 router.include_router(event_admin_router)
 router.include_router(admin_config_router)
+router.include_router(trivia_admin_router)
 
 @router.message(CommandStart())
 async def admin_start(message: Message, session: AsyncSession):

--- a/mybot/handlers/admin/trivia_admin.py
+++ b/mybot/handlers/admin/trivia_admin.py
@@ -1,0 +1,178 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils.user_roles import is_admin
+from utils.menu_utils import update_menu, send_temporary_reply
+from utils.keyboard_utils import (
+    get_admin_content_trivia_keyboard,
+)
+from keyboards.common import get_back_keyboard
+from utils.admin_state import AdminTriviaStates
+from services.trivia_service import TriviaService
+
+router = Router()
+
+
+@router.callback_query(F.data == "admin_content_trivia")
+async def admin_content_trivia(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await update_menu(
+        callback,
+        "❓ Gestionar Trivias - Selecciona una opción:",
+        get_admin_content_trivia_keyboard(),
+        session,
+        "admin_content_trivia",
+    )
+    await callback.answer()
+
+
+async def show_trivia_page(message: Message, session: AsyncSession, page: int = 0) -> None:
+    limit = 5
+    if page < 0:
+        page = 0
+
+    service = TriviaService(session)
+    trivias, total = await service.list_trivias(offset=page * limit, limit=limit)
+
+    lines = []
+    for t in trivias:
+        lines.append(
+            f"ID {t.id}: {t.question[:40]}... ({t.reward_points} pts)"
+        )
+
+    text = "\n".join(lines) if lines else "No hay trivias registradas."
+
+    keyboard: list[list[InlineKeyboardButton]] = []
+    from utils.pagination import get_pagination_buttons
+
+    for t in trivias:
+        keyboard.append(
+            [
+                InlineKeyboardButton(text="✏️", callback_data=f"trivia_edit:{t.id}"),
+                InlineKeyboardButton(text="🗑", callback_data=f"trivia_delete:{t.id}"),
+            ]
+        )
+
+    total_pages = (total + limit - 1) // limit
+    nav = get_pagination_buttons(page, total_pages, "trivia_page")
+    if nav:
+        keyboard.append(nav)
+
+    keyboard.append([InlineKeyboardButton(text="🔙 Volver", callback_data="admin_content_trivia")])
+    await message.edit_text(text, reply_markup=InlineKeyboardMarkup(inline_keyboard=keyboard))
+
+
+@router.callback_query(F.data == "admin_trivia_list")
+async def admin_trivia_list(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await show_trivia_page(callback.message, session, 0)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("trivia_page:"))
+async def trivia_page(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    try:
+        page = int(callback.data.split(":", 1)[1])
+    except (IndexError, ValueError):
+        page = 0
+    await show_trivia_page(callback.message, session, page)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "admin_trivia_create")
+async def trivia_create_start(callback: CallbackQuery, state: FSMContext):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    await callback.message.edit_text(
+        "Código de activación de la trivia:",
+        reply_markup=get_back_keyboard("admin_content_trivia"),
+    )
+    await state.set_state(AdminTriviaStates.creating_trigger)
+    await callback.answer()
+
+
+from keyboards.common import get_back_keyboard
+
+@router.message(AdminTriviaStates.creating_trigger)
+async def trivia_create_trigger(message: Message, state: FSMContext):
+    await state.update_data(trigger_code=message.text.strip())
+    await message.answer("Pregunta de la trivia:")
+    await state.set_state(AdminTriviaStates.creating_question)
+
+
+@router.message(AdminTriviaStates.creating_question)
+async def trivia_create_question(message: Message, state: FSMContext):
+    await state.update_data(question=message.text)
+    await message.answer("Opciones separadas por '|':")
+    await state.set_state(AdminTriviaStates.creating_options)
+
+
+@router.message(AdminTriviaStates.creating_options)
+async def trivia_create_options(message: Message, state: FSMContext):
+    opts = [o.strip() for o in message.text.split("|") if o.strip()]
+    await state.update_data(options=opts)
+    await message.answer("Índice de la respuesta correcta (empezando en 1):")
+    await state.set_state(AdminTriviaStates.creating_correct)
+
+
+@router.message(AdminTriviaStates.creating_correct)
+async def trivia_create_correct(message: Message, state: FSMContext):
+    try:
+        idx = int(message.text) - 1
+    except ValueError:
+        await send_temporary_reply(message, "Número inválido")
+        return
+    await state.update_data(correct_index=idx)
+    await message.answer("Puntos por respuesta correcta (0 para ninguno):")
+    await state.set_state(AdminTriviaStates.creating_reward)
+
+
+@router.message(AdminTriviaStates.creating_reward)
+async def trivia_create_reward(message: Message, state: FSMContext):
+    try:
+        points = int(message.text)
+    except ValueError:
+        await send_temporary_reply(message, "Número inválido")
+        return
+    await state.update_data(reward_points=points)
+    await message.answer("Código de pista a desbloquear ('-' para omitir):")
+    await state.set_state(AdminTriviaStates.creating_unlock)
+
+
+@router.message(AdminTriviaStates.creating_unlock)
+async def trivia_create_unlock(message: Message, state: FSMContext, session: AsyncSession):
+    code = message.text.strip()
+    if code == "-":
+        code = None
+    data = await state.get_data()
+    service = TriviaService(session)
+    await service.create_trivia(
+        data["trigger_code"],
+        data["question"],
+        data["options"],
+        data["correct_index"],
+        data["reward_points"],
+        unlocks_lore_piece_code=code,
+    )
+    await message.answer(
+        "Trivia creada.", reply_markup=get_back_keyboard("admin_content_trivia")
+    )
+    await state.clear()
+
+
+@router.callback_query(F.data.startswith("trivia_delete:"))
+async def trivia_delete(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+    tid = int(callback.data.split(":", 1)[1])
+    service = TriviaService(session)
+    await service.delete_trivia(tid)
+    await callback.answer("Eliminada", show_alert=True)
+    await show_trivia_page(callback.message, session, 0)
+

--- a/mybot/handlers/trivia.py
+++ b/mybot/handlers/trivia.py
@@ -1,0 +1,43 @@
+from aiogram import Router, F
+from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.trivia_service import TriviaService
+from utils.messages import BOT_MESSAGES
+
+router = Router()
+
+
+@router.message(F.text.startswith('/trivia'))
+async def trivia_command(message: Message, session: AsyncSession):
+    parts = message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer('Debes indicar el código de la trivia. Uso: /trivia <codigo>')
+        return
+    code = parts[1].strip()
+    service = TriviaService(session)
+    trivia = await service.get_trivia_by_code(code)
+    if not trivia:
+        await message.answer('Trivia no encontrada.')
+        return
+    buttons = [
+        [InlineKeyboardButton(text=opt, callback_data=f'trivia_ans:{trivia.id}:{i}')]
+        for i, opt in enumerate(trivia.options)
+    ]
+    await message.answer(trivia.question, reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons))
+
+
+@router.callback_query(F.data.startswith('trivia_ans:'))
+async def trivia_answer(callback: CallbackQuery, session: AsyncSession, bot):
+    _, tid, idx = callback.data.split(':')
+    trivia_service = TriviaService(session)
+    trivia = await trivia_service.get_trivia_by_id(int(tid))
+    if not trivia:
+        return await callback.answer('Trivia no disponible', show_alert=True)
+    correct = await trivia_service.answer_trivia(callback.from_user.id, trivia, int(idx), bot=bot)
+    if correct:
+        text = BOT_MESSAGES.get('trivia_correct', '¡Correcto!')
+    else:
+        text = BOT_MESSAGES.get('trivia_wrong', 'Respuesta incorrecta.')
+    await callback.message.edit_text(text)
+    await callback.answer()

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -15,6 +15,7 @@ from .message_service import MessageService
 from .auction_service import AuctionService
 from .user_service import UserService
 from .lore_piece_service import LorePieceService
+from .trivia_service import TriviaService
 from .scheduler import channel_request_scheduler, vip_subscription_scheduler, vip_membership_scheduler
 
 __all__ = [
@@ -40,4 +41,5 @@ __all__ = [
     "AuctionService",
     "UserService",
     "LorePieceService",
+    "TriviaService",
 ]

--- a/mybot/services/trivia_service.py
+++ b/mybot/services/trivia_service.py
@@ -1,0 +1,124 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, func
+from aiogram import Bot
+
+from database.models import (
+    Trivia,
+    TriviaResult,
+    User,
+    LorePiece,
+    UserLorePiece,
+)
+from .point_service import PointService
+from .level_service import LevelService
+
+
+class TriviaService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.point_service = PointService(session)
+        self.level_service = LevelService(session)
+
+    async def create_trivia(
+        self,
+        trigger_code: str,
+        question: str,
+        options: list[str],
+        correct_index: int,
+        reward_points: int = 0,
+        unlocks_lore_piece_code: str | None = None,
+        level_increment: int = 0,
+    ) -> Trivia:
+        trivia = Trivia(
+            trigger_code=trigger_code,
+            question=question,
+            options=options,
+            correct_index=correct_index,
+            reward_points=reward_points,
+            unlocks_lore_piece_code=unlocks_lore_piece_code,
+            level_increment=level_increment,
+        )
+        self.session.add(trivia)
+        await self.session.commit()
+        await self.session.refresh(trivia)
+        return trivia
+
+    async def list_trivias(self, offset: int = 0, limit: int = 5) -> tuple[list[Trivia], int]:
+        total = (await self.session.execute(select(func.count()).select_from(Trivia))).scalar_one()
+        result = await self.session.execute(
+            select(Trivia).order_by(Trivia.id).offset(offset).limit(limit)
+        )
+        return result.scalars().all(), total
+
+    async def get_trivia_by_id(self, trivia_id: int) -> Trivia | None:
+        return await self.session.get(Trivia, trivia_id)
+
+    async def get_trivia_by_code(self, trigger_code: str) -> Trivia | None:
+        stmt = select(Trivia).where(Trivia.trigger_code == trigger_code, Trivia.is_active == True)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def update_trivia(
+        self,
+        trivia_id: int,
+        **kwargs,
+    ) -> bool:
+        trivia = await self.session.get(Trivia, trivia_id)
+        if not trivia:
+            return False
+        for field, value in kwargs.items():
+            if hasattr(trivia, field) and value is not None:
+                setattr(trivia, field, value)
+        await self.session.commit()
+        return True
+
+    async def delete_trivia(self, trivia_id: int) -> bool:
+        trivia = await self.session.get(Trivia, trivia_id)
+        if not trivia:
+            return False
+        await self.session.delete(trivia)
+        await self.session.commit()
+        return True
+
+    async def answer_trivia(
+        self, user_id: int, trivia: Trivia, option_index: int, bot: Bot | None = None
+    ) -> bool:
+        correct = option_index == trivia.correct_index
+        exists_stmt = select(TriviaResult).where(
+            TriviaResult.user_id == user_id, TriviaResult.trivia_id == trivia.id
+        )
+        existing = (await self.session.execute(exists_stmt)).scalar_one_or_none()
+        if existing:
+            return correct
+
+        self.session.add(
+            TriviaResult(user_id=user_id, trivia_id=trivia.id, is_correct=correct)
+        )
+        if correct and trivia.reward_points:
+            await self.point_service.add_points(user_id, trivia.reward_points, bot=bot)
+        if correct and trivia.level_increment:
+            user = await self.session.get(User, user_id)
+            if user:
+                user.level += trivia.level_increment
+                self.session.add(user)
+                await self.session.commit()
+                await self.level_service.check_for_level_up(user, bot=bot)
+        await self.session.commit()
+
+        if correct and trivia.unlocks_lore_piece_code:
+            lore_stmt = select(LorePiece).where(
+                LorePiece.code_name == trivia.unlocks_lore_piece_code
+            )
+            piece = (await self.session.execute(lore_stmt)).scalar_one_or_none()
+            if piece:
+                check_stmt = select(UserLorePiece).where(
+                    UserLorePiece.user_id == user_id,
+                    UserLorePiece.lore_piece_id == piece.id,
+                )
+                exists = (await self.session.execute(check_stmt)).scalar_one_or_none()
+                if not exists:
+                    self.session.add(
+                        UserLorePiece(user_id=user_id, lore_piece_id=piece.id)
+                    )
+                    await self.session.commit()
+        return correct

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -189,3 +189,21 @@ class AdminVipSubscriberStates(StatesGroup):
 
     waiting_for_days = State()
     waiting_for_new_date = State()
+
+
+class AdminTriviaStates(StatesGroup):
+    """States for managing trivia questions."""
+
+    creating_trigger = State()
+    creating_question = State()
+    creating_options = State()
+    creating_correct = State()
+    creating_reward = State()
+    creating_unlock = State()
+
+    editing_select = State()
+    editing_question = State()
+    editing_options = State()
+    editing_correct = State()
+    editing_reward = State()
+    editing_unlock = State()

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -231,6 +231,11 @@ def get_admin_manage_content_keyboard():
             ],
             [
                 InlineKeyboardButton(
+                    text="❓ Trivias", callback_data="admin_content_trivia"
+                )
+            ],
+            [
+                InlineKeyboardButton(
                     text="🎒 Administrar Pistas",
                     callback_data="admin_content_lore_pieces",
                 )
@@ -423,6 +428,18 @@ def get_admin_content_minigames_keyboard():
                     text="🔙 Volver", callback_data="admin_manage_content"
                 )
             ],
+        ]
+    )
+    return keyboard
+
+
+def get_admin_content_trivia_keyboard():
+    """Keyboard for managing trivia questions."""
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="➕ Crear Trivia", callback_data="admin_trivia_create")],
+            [InlineKeyboardButton(text="📋 Ver Trivias", callback_data="admin_trivia_list")],
+            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
         ]
     )
     return keyboard


### PR DESCRIPTION
## Summary
- add Trivia and TriviaResult models
- implement TriviaService for trivia logic
- add admin handlers and keyboards for managing trivia
- support /trivia command for users
- register new routers and states

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861d43f5b7c8329b14571c093c8ddfc