### PR TITLE
Implement admin-managed trivia system

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -411,6 +411,39 @@ class MiniGamePlay(AsyncAttrs, Base):
     cost_points = Column(Float, default=0)
 
 
+class Trivia(AsyncAttrs, Base):
+    """Multiple choice trivia questions for the gamification system."""
+
+    __tablename__ = "trivias"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    code_name = Column(String, unique=True, nullable=False)
+    question = Column(Text, nullable=False)
+    options = Column(JSON, nullable=False)
+    correct_index = Column(Integer, nullable=False)
+    reward_points = Column(Integer, default=0)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=func.now())
+
+
+class UserTriviaResult(AsyncAttrs, Base):
+    """Stores user answers and scores for trivias."""
+
+    __tablename__ = "user_trivia_results"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(BigInteger, ForeignKey("users.id"), nullable=False)
+    trivia_id = Column(Integer, ForeignKey("trivias.id"), nullable=False)
+    selected_index = Column(Integer, nullable=False)
+    is_correct = Column(Boolean, nullable=False)
+    points_awarded = Column(Integer, default=0)
+    answered_at = Column(DateTime, default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "trivia_id", name="uix_user_trivia"),
+    )
+
+
 class LorePiece(AsyncAttrs, Base):
     """Discrete lore or clue piece that users can unlock."""
 

--- a/mybot/services/trivia_service.py
+++ b/mybot/services/trivia_service.py
@@ -1,0 +1,108 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from aiogram import Bot
+
+from database.models import Trivia, UserTriviaResult
+from .point_service import PointService
+
+
+class TriviaService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.point_service = PointService(session)
+
+    async def create_trivia(
+        self,
+        code_name: str,
+        question: str,
+        options: list[str],
+        correct_index: int,
+        reward_points: int = 0,
+    ) -> Trivia:
+        trivia = Trivia(
+            code_name=code_name.strip(),
+            question=question.strip(),
+            options=options,
+            correct_index=correct_index,
+            reward_points=reward_points,
+        )
+        self.session.add(trivia)
+        await self.session.commit()
+        await self.session.refresh(trivia)
+        return trivia
+
+    async def list_trivias(self) -> list[Trivia]:
+        result = await self.session.execute(select(Trivia).order_by(Trivia.id))
+        return result.scalars().all()
+
+    async def get_trivia_by_id(self, trivia_id: int) -> Trivia | None:
+        return await self.session.get(Trivia, trivia_id)
+
+    async def update_trivia(
+        self,
+        trivia_id: int,
+        *,
+        code_name: str | None = None,
+        question: str | None = None,
+        options: list[str] | None = None,
+        correct_index: int | None = None,
+        reward_points: int | None = None,
+        is_active: bool | None = None,
+    ) -> bool:
+        trivia = await self.session.get(Trivia, trivia_id)
+        if not trivia:
+            return False
+        if code_name is not None:
+            trivia.code_name = code_name.strip()
+        if question is not None:
+            trivia.question = question.strip()
+        if options is not None:
+            trivia.options = options
+        if correct_index is not None:
+            trivia.correct_index = correct_index
+        if reward_points is not None:
+            trivia.reward_points = reward_points
+        if is_active is not None:
+            trivia.is_active = is_active
+        await self.session.commit()
+        return True
+
+    async def delete_trivia(self, trivia_id: int) -> bool:
+        trivia = await self.session.get(Trivia, trivia_id)
+        if not trivia:
+            return False
+        await self.session.delete(trivia)
+        await self.session.commit()
+        return True
+
+    async def record_answer(
+        self,
+        user_id: int,
+        trivia_id: int,
+        selected_index: int,
+        bot: Bot | None = None,
+    ) -> tuple[bool, bool, int]:
+        trivia = await self.session.get(Trivia, trivia_id)
+        if not trivia or not trivia.is_active:
+            return False, False, 0
+        stmt = select(UserTriviaResult).where(
+            UserTriviaResult.user_id == user_id,
+            UserTriviaResult.trivia_id == trivia_id,
+        )
+        existing = (await self.session.execute(stmt)).scalar_one_or_none()
+        if existing:
+            return False, existing.is_correct, existing.points_awarded
+        is_correct = selected_index == trivia.correct_index
+        points = trivia.reward_points if is_correct else 0
+        result = UserTriviaResult(
+            user_id=user_id,
+            trivia_id=trivia_id,
+            selected_index=selected_index,
+            is_correct=is_correct,
+            points_awarded=points,
+        )
+        self.session.add(result)
+        if points:
+            await self.point_service.add_points(user_id, points, bot=bot)
+        await self.session.commit()
+        return True, is_correct, points

--- a/mybot/utils/admin_state.py
+++ b/mybot/utils/admin_state.py
@@ -189,3 +189,21 @@ class AdminVipSubscriberStates(StatesGroup):
 
     waiting_for_days = State()
     waiting_for_new_date = State()
+
+
+class AdminTriviaStates(StatesGroup):
+    """States for creating and editing trivia questions."""
+
+    creating_question = State()
+    creating_options = State()
+    creating_correct_index = State()
+    creating_reward = State()
+    creating_code = State()
+
+    editing_select_trivia = State()
+    editing_question = State()
+    editing_options = State()
+    editing_correct_index = State()
+    editing_reward = State()
+    editing_code = State()
+    deleting_trivia = State()

--- a/mybot/utils/keyboard_utils.py
+++ b/mybot/utils/keyboard_utils.py
@@ -216,6 +216,12 @@ def get_admin_manage_content_keyboard():
             ],
             [
                 InlineKeyboardButton(
+                    text="❓ Trivias",
+                    callback_data="admin_content_trivias",
+                )
+            ],
+            [
+                InlineKeyboardButton(
                     text="🏛️ Subastas", callback_data="admin_auction_main"
                 )
             ],
@@ -423,6 +429,20 @@ def get_admin_content_minigames_keyboard():
                     text="🔙 Volver", callback_data="admin_manage_content"
                 )
             ],
+        ]
+    )
+    return keyboard
+
+
+def get_admin_content_trivias_keyboard():
+    """Keyboard for trivia management options."""
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="➕ Crear Trivia", callback_data="admin_trivia_create")],
+            [InlineKeyboardButton(text="📝 Editar Trivia", callback_data="admin_trivia_edit")],
+            [InlineKeyboardButton(text="🗑 Eliminar Trivia", callback_data="admin_trivia_delete")],
+            [InlineKeyboardButton(text="📋 Ver Trivias", callback_data="admin_trivia_list")],
+            [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_manage_content")],
         ]
     )
     return keyboard


### PR DESCRIPTION
## Summary
- add Trivia and UserTriviaResult models
- create TriviaService for CRUD operations
- support trivia management states
- extend admin keyboards with new trivia section
- implement admin handlers for creating, viewing, editing and deleting trivia

## Testing
- `python -m py_compile mybot/services/trivia_service.py mybot/utils/keyboard_utils.py mybot/handlers/admin/game_admin.py mybot/utils/admin_state.py mybot/database/models.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_6861d9d1f79c832983c18ba4ba64565e