### PR TITLE
Add initial trivia engine skeleton

### DIFF
--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -446,6 +446,67 @@ class UserLorePiece(AsyncAttrs, Base):
     )
 
 
+# --- Trivia System Models ---
+class TriviaTemplate(AsyncAttrs, Base):
+    __tablename__ = "trivia_templates"
+
+    id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    description = Column(Text)
+    trigger_events = Column(JSON)
+    trigger_conditions = Column(JSON)
+    question_pool = Column(JSON)
+    selection_strategy = Column(String)
+    max_questions = Column(Integer, default=5)
+    min_score_percentage = Column(Float, default=0.6)
+    rewards = Column(JSON)
+    unlock_storyboards = Column(JSON)
+    special_content_unlocks = Column(JSON)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=func.now())
+
+
+class TriviaQuestionModel(AsyncAttrs, Base):
+    __tablename__ = "trivia_questions"
+
+    id = Column(String, primary_key=True)
+    question = Column(Text, nullable=False)
+    question_type = Column(String)
+    options = Column(JSON)
+    correct_answer = Column(JSON)
+    explanation = Column(Text)
+    difficulty = Column(Integer, default=1)
+    time_limit = Column(Integer)
+    media_url = Column(String)
+    tags = Column(JSON)
+    created_at = Column(DateTime, default=func.now())
+
+
+class UserTriviaHistory(AsyncAttrs, Base):
+    __tablename__ = "user_trivia_history"
+
+    id = Column(String, primary_key=True)
+    user_id = Column(BigInteger, nullable=False)
+    template_id = Column(String)
+    session_id = Column(String)
+    score = Column(Integer)
+    total_questions = Column(Integer)
+    completion_time = Column(Integer)
+    triggered_by = Column(String)
+    rewards_earned = Column(JSON)
+    completed_at = Column(DateTime, default=func.now())
+
+
+class UnlockedContent(AsyncAttrs, Base):
+    __tablename__ = "unlocked_content"
+
+    user_id = Column(BigInteger, primary_key=True)
+    content_type = Column(String, primary_key=True)
+    content_id = Column(String, primary_key=True)
+    unlocked_by = Column(String)
+    unlocked_at = Column(DateTime, default=func.now())
+
+
 
 # Funciones para manejar el estado del menú del usuario
 async def get_user_menu_state(session, user_id: int) -> str:

--- a/mybot/states/__init__.py
+++ b/mybot/states/__init__.py
@@ -1,5 +1,7 @@
 from .gamification_states import LorePieceAdminStates
+from .trivia_states import TriviaStates
 
 __all__ = [
     "LorePieceAdminStates",
+    "TriviaStates",
 ]

--- a/mybot/states/trivia_states.py
+++ b/mybot/states/trivia_states.py
@@ -1,0 +1,13 @@
+from aiogram.fsm.state import StatesGroup, State
+
+class TriviaStates(StatesGroup):
+    waiting_trigger = State()
+    trivia_intro = State()
+    answering_question = State()
+    waiting_answer = State()
+    processing_answer = State()
+    showing_result = State()
+    showing_explanation = State()
+    session_complete = State()
+    reward_processing = State()
+    unlocking_content = State()

--- a/mybot/trivia/__init__.py
+++ b/mybot/trivia/__init__.py
@@ -1,0 +1,18 @@
+from .schema import *
+from .manager import TriviaManager
+from .content import TriviaContentDelivery
+
+__all__ = [
+    "TriviaManager",
+    "TriviaType",
+    "TriggerEvent",
+    "RewardType",
+    "TriviaReward",
+    "TriviaQuestion",
+    "TriviaSession",
+    "TriviaTemplate",
+    "TriviaContentDelivery",
+    "trivia_router",
+]
+from .router import router as trivia_router
+

--- a/mybot/trivia/content.py
+++ b/mybot/trivia/content.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from aiogram import Bot
+from aiogram.types import InlineKeyboardButton
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from .schema import TriviaSession, TriviaType
+
+
+class TriviaContentDelivery:
+    @staticmethod
+    async def send_trivia_intro(bot: Bot, session: TriviaSession):
+        text = f"\U0001F3AF {session.triggered_by}"
+        builder = InlineKeyboardBuilder()
+        builder.button(text="\u2728 Comenzar", callback_data="trivia_start")
+        builder.button(text="Cancelar", callback_data="trivia_cancel")
+        await bot.send_message(session.user_id, text, reply_markup=builder.as_markup())
+
+    @staticmethod
+    async def send_question(bot: Bot, session: TriviaSession):
+        question = session.questions[session.current_question_index]
+        text = question.question
+        builder = InlineKeyboardBuilder()
+        if question.question_type == TriviaType.MULTIPLE_CHOICE and question.options:
+            for i, option in enumerate(question.options):
+                builder.button(text=f"{chr(65+i)}) {option}", callback_data=f"trivia_answer_{i}")
+        await bot.send_message(session.user_id, text, reply_markup=builder.as_markup())
+
+    @staticmethod
+    async def send_answer_result(bot: Bot, session: TriviaSession, is_correct: bool, explanation: str):
+        text = "\u2705 Correcto" if is_correct else "\u274C Incorrecto"
+        if explanation:
+            text += f"\n{explanation}"
+        builder = InlineKeyboardBuilder()
+        if session.current_question_index + 1 < len(session.questions):
+            builder.button(text="Siguiente", callback_data="trivia_next")
+        else:
+            builder.button(text="Finalizar", callback_data="trivia_complete")
+        await bot.send_message(session.user_id, text, reply_markup=builder.as_markup())

--- a/mybot/trivia/events.py
+++ b/mybot/trivia/events.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .schema import TriggerEvent
+from .manager import TriviaManager
+
+
+class GameEventListener:
+    def __init__(self, trivia_manager: TriviaManager, storyboard_manager, points_system):
+        self.trivia_manager = trivia_manager
+        self.storyboard_manager = storyboard_manager
+        self.points_system = points_system
+
+    async def on_level_up(self, user_id: int, old_level: int, new_level: int):
+        await self.trivia_manager.check_triggers(
+            user_id=user_id,
+            event=TriggerEvent.LEVEL_UP,
+            context={"old_level": old_level, "new_level": new_level},
+        )
+
+    async def on_points_milestone(self, user_id: int, points: int, milestone: int):
+        await self.trivia_manager.check_triggers(
+            user_id=user_id,
+            event=TriggerEvent.POINTS_MILESTONE,
+            context={"points": points, "milestone": milestone},
+        )
+
+    async def on_story_completion(self, user_id: int, story_id: str):
+        await self.trivia_manager.check_triggers(
+            user_id=user_id,
+            event=TriggerEvent.STORY_COMPLETION,
+            context={"story_id": story_id},
+        )

--- a/mybot/trivia/manager.py
+++ b/mybot/trivia/manager.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import random
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from aiogram import Bot
+from aiogram.fsm.context import FSMContext
+
+from .schema import (
+    TriviaSession,
+    TriviaTemplate,
+    TriviaQuestion,
+    TriggerEvent,
+)
+
+
+class TriviaManager:
+    def __init__(self, bot: Bot, db_session, points_system, storyboard_manager):
+        self.bot = bot
+        self.db = db_session
+        self.points_system = points_system
+        self.storyboard_manager = storyboard_manager
+        self.active_sessions: Dict[int, TriviaSession] = {}
+
+    async def check_triggers(self, user_id: int, event: TriggerEvent, context: Dict[str, Any]):
+        templates = await self.get_triggered_templates(event, user_id, context)
+        for template in templates:
+            if await self.meets_requirements(user_id, template, context):
+                await self.start_trivia_session(user_id, template, context)
+
+    async def get_triggered_templates(
+        self, event: TriggerEvent, user_id: int, context: Dict[str, Any]
+    ) -> List[TriviaTemplate]:
+        # Placeholder: fetch templates from DB matching event
+        return []
+
+    async def meets_requirements(
+        self, user_id: int, template: TriviaTemplate, context: Dict[str, Any]
+    ) -> bool:
+        # TODO: implement requirement checks
+        return True
+
+    async def get_user_level(self, user_id: int) -> int:
+        # Placeholder using points_system
+        return await self.points_system.get_level(user_id)
+
+    async def select_questions(
+        self, template: TriviaTemplate, user_id: int
+    ) -> List[TriviaQuestion]:
+        # TODO: implement question selection logic
+        return []
+
+    async def start_trivia_session(
+        self, user_id: int, template: TriviaTemplate, context: Dict[str, Any]
+    ) -> None:
+        questions = await self.select_questions(template, user_id)
+        session = TriviaSession(
+            id=f"trivia_{user_id}_{datetime.now().timestamp()}",
+            user_id=user_id,
+            channel_id=context.get("channel_id", user_id),
+            questions=questions,
+            triggered_by=template.id,
+            context=context,
+            rewards_on_correct=template.rewards.get("correct", []),
+            rewards_on_wrong=template.rewards.get("wrong", []),
+            rewards_on_completion=template.rewards.get("completion", []),
+        )
+        self.active_sessions[user_id] = session
+        from .content import TriviaContentDelivery
+        await TriviaContentDelivery.send_trivia_intro(self.bot, session)
+
+    async def process_answer(self, user_id: int, answer: str, state: FSMContext) -> None:
+        session = self.active_sessions.get(user_id)
+        if not session:
+            return
+        # TODO: validate answer and update score
+        session.current_question_index += 1
+        if session.current_question_index >= len(session.questions):
+            await self.complete_trivia_session(session, state)
+        else:
+            await self.send_next_question(session)
+
+    async def complete_trivia_session(self, session: TriviaSession, state: FSMContext) -> None:
+        # TODO: process completion rewards and clean up
+        if session.user_id in self.active_sessions:
+            del self.active_sessions[session.user_id]
+        await state.set_state(None)
+
+    async def send_answer_result(self, session: TriviaSession, is_correct: bool, explanation: str | None = None) -> None:
+        from .content import TriviaContentDelivery
+        await TriviaContentDelivery.send_answer_result(self.bot, session, is_correct, explanation or "")
+
+    async def send_next_question(self, session: TriviaSession) -> None:
+        from .content import TriviaContentDelivery
+        await TriviaContentDelivery.send_question(self.bot, session)
+

--- a/mybot/trivia/rewards.py
+++ b/mybot/trivia/rewards.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .schema import RewardType, TriviaReward
+
+
+class RewardProcessor:
+    def __init__(self, points_system, storyboard_manager, content_manager):
+        self.points_system = points_system
+        self.storyboard_manager = storyboard_manager
+        self.content_manager = content_manager
+
+    async def process_reward(self, user_id: int, reward: TriviaReward, context: Dict[str, Any]):
+        if reward.type == RewardType.POINTS:
+            await self.points_system.add_points(user_id, reward.value)
+        elif reward.type == RewardType.LEVEL_BOOST:
+            await self.points_system.boost_level(user_id, reward.value)
+        elif reward.type == RewardType.SPECIAL_CONTENT:
+            await self.content_manager.unlock_content(user_id, reward.value)
+        elif reward.type == RewardType.STORYBOARD_UNLOCK:
+            await self.storyboard_manager.unlock_storyboard(user_id, reward.value)
+        elif reward.type == RewardType.ACHIEVEMENT:
+            await self.content_manager.unlock_achievement(user_id, reward.value)
+        if reward.immediate:
+            await self.trigger_immediate_effects(user_id, reward, context)
+
+    async def trigger_immediate_effects(self, user_id: int, reward: TriviaReward, context: Dict[str, Any]):
+        # Placeholder for custom logic
+        pass

--- a/mybot/trivia/router.py
+++ b/mybot/trivia/router.py
@@ -1,0 +1,19 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery, Message
+from aiogram.filters import StateFilter, Command
+from aiogram.fsm.context import FSMContext
+
+from .manager import TriviaManager
+from ..states.trivia_states import TriviaStates
+
+router = Router()
+
+@router.callback_query(F.data.startswith("trivia_answer_"), StateFilter(TriviaStates.waiting_answer))
+async def handle_trivia_answer(callback: CallbackQuery, state: FSMContext, trivia_manager: TriviaManager):
+    answer = callback.data.split("trivia_answer_")[1]
+    await trivia_manager.process_answer(callback.from_user.id, answer, state)
+    await callback.answer()
+
+@router.message(StateFilter(TriviaStates.waiting_answer))
+async def handle_text_answer(message: Message, state: FSMContext, trivia_manager: TriviaManager):
+    await trivia_manager.process_answer(message.from_user.id, message.text, state)

--- a/mybot/trivia/schema.py
+++ b/mybot/trivia/schema.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+class TriviaType(Enum):
+    MULTIPLE_CHOICE = "multiple_choice"
+    TRUE_FALSE = "true_false"
+    OPEN_TEXT = "open_text"
+    SEQUENCE = "sequence"
+    TIMED_CHALLENGE = "timed_challenge"
+    PROGRESSIVE = "progressive"
+
+class TriggerEvent(Enum):
+    LEVEL_UP = "level_up"
+    POINTS_MILESTONE = "points_milestone"
+    ACHIEVEMENT_UNLOCK = "achievement_unlock"
+    TIME_BASED = "time_based"
+    STORY_COMPLETION = "story_completion"
+    BOSS_DEFEAT = "boss_defeat"
+    SPECIAL_ACTION = "special_action"
+    RANDOM_ENCOUNTER = "random_encounter"
+
+class RewardType(Enum):
+    POINTS = "points"
+    LEVEL_BOOST = "level_boost"
+    SPECIAL_CONTENT = "special_content"
+    STORYBOARD_UNLOCK = "storyboard_unlock"
+    ACHIEVEMENT = "achievement"
+    ITEM = "item"
+    ACCESS_PRIVILEGE = "access_privilege"
+
+@dataclass
+class TriviaReward:
+    type: RewardType
+    value: Union[int, str, Dict[str, Any]]
+    condition: str
+    immediate: bool = True
+    unlock_requirements: Optional[Dict[str, Any]] = None
+
+@dataclass
+class TriviaQuestion:
+    id: str
+    question: str
+    question_type: TriviaType
+    options: Optional[List[str]] = None
+    correct_answer: Union[str, int, List[str], None] = None
+    explanation: Optional[str] = None
+    difficulty: int = 1
+    time_limit: Optional[int] = None
+    media_url: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+
+@dataclass
+class TriviaSession:
+    id: str
+    user_id: int
+    channel_id: int
+    questions: List[TriviaQuestion]
+    current_question_index: int = 0
+    score: int = 0
+    start_time: datetime = field(default_factory=datetime.now)
+    time_limit: Optional[int] = None
+    rewards_on_correct: List[TriviaReward] = field(default_factory=list)
+    rewards_on_wrong: List[TriviaReward] = field(default_factory=list)
+    rewards_on_completion: List[TriviaReward] = field(default_factory=list)
+    triggered_by: Optional[str] = None
+    context: Dict[str, Any] = field(default_factory=dict)
+
+@dataclass
+class TriviaTemplate:
+    id: str
+    name: str
+    description: str
+    trigger_events: List[TriggerEvent]
+    trigger_conditions: Dict[str, Any]
+    question_pool: List[str]
+    selection_strategy: str
+    max_questions: int = 5
+    min_score_percentage: float = 0.6
+    rewards: Dict[str, List[TriviaReward]] = field(default_factory=dict)
+    unlock_storyboards: List[str] = field(default_factory=list)
+    special_content_unlocks: List[str] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- implement trivia schema and states
- add skeleton TriviaManager with router
- integrate trivia router in bot
- extend database models for trivia templates and questions

## Testing
- `python -m compileall -q mybot/trivia mybot/states mybot/database/models.py mybot/bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6861e3437e148329a26ca13e7900b419