### PR TITLE
Fix trivia router import

### DIFF
--- a/mybot/trivia/router.py
+++ b/mybot/trivia/router.py
@@ -4,7 +4,7 @@ from aiogram.filters import StateFilter, Command
 from aiogram.fsm.context import FSMContext
 
 from .manager import TriviaManager
-from ..states.trivia_states import TriviaStates
+from states.trivia_states import TriviaStates
 
 router = Router()
 


### PR DESCRIPTION
## Summary
- use absolute import for trivia state machine

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861f8cb2c1c8329b4de78217e316eaa