### PR TITLE
Add admin trivia scaffolding

### DIFF
--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -7,6 +7,7 @@ from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
 from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
+from .trivia_admin import router as trivia_admin_router
 
 __all__ = [
     "admin_router",
@@ -18,4 +19,5 @@ __all__ = [
     "game_admin_router",
     "event_admin_router",
     "admin_config_router",
+    "trivia_admin_router",
 ]

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -33,6 +33,7 @@ from .subscription_plans import router as subscription_plans_router
 from .game_admin import router as game_admin_router
 from .event_admin import router as event_admin_router
 from .admin_config import router as admin_config_router
+from .trivia_admin import router as trivia_admin_router
 
 router.include_router(vip_router)
 router.include_router(free_router)
@@ -42,6 +43,7 @@ router.include_router(subscription_plans_router)
 router.include_router(game_admin_router)
 router.include_router(event_admin_router)
 router.include_router(admin_config_router)
+router.include_router(trivia_admin_router)
 
 @router.message(CommandStart())
 async def admin_start(message: Message, session: AsyncSession):

--- a/mybot/handlers/admin/trivia_admin.py
+++ b/mybot/handlers/admin/trivia_admin.py
@@ -1,0 +1,31 @@
+from aiogram import Router, F
+from aiogram.types import CallbackQuery
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils.user_roles import is_admin
+from utils.menu_manager import menu_manager
+from keyboards.admin_trivia_kb import get_admin_trivia_main_kb
+
+router = Router()
+
+async def show_trivia_main_menu(callback: CallbackQuery, session: AsyncSession) -> None:
+    await menu_manager.update_menu(
+        callback,
+        "🎲 **Administración de Trivias**",
+        get_admin_trivia_main_kb(),
+        session,
+        "admin_trivia_main",
+    )
+
+@router.callback_query(F.data == "admin_trivia_main")
+async def trivia_admin_main(callback: CallbackQuery, session: AsyncSession):
+    if not is_admin(callback.from_user.id):
+        return await callback.answer("❌ No tienes permisos para gestionar trivias", show_alert=True)
+
+    await show_trivia_main_menu(callback, session)
+    await callback.answer()
+
+@router.callback_query(F.data == "admin_trivia_questions")
+async def trivia_questions_menu(callback: CallbackQuery, state: FSMContext):
+    await callback.answer("Gestión de preguntas próximamente", show_alert=True)

--- a/mybot/keyboards/admin_main_kb.py
+++ b/mybot/keyboards/admin_main_kb.py
@@ -9,6 +9,8 @@ def get_admin_main_kb():
     builder.button(text="💬 Canal Free", callback_data="admin_free")
     builder.button(text="🎮 Juego Kinky", callback_data="admin_kinky_game")
 
+    builder.button(text="🎲 Trivias", callback_data="admin_trivia_main")
+
    
     builder.button(text="🛠 Configuración del Bot", callback_data="admin_config")
     builder.button(text="📈 Estadísticas", callback_data="admin_stats")

--- a/mybot/keyboards/admin_trivia_kb.py
+++ b/mybot/keyboards/admin_trivia_kb.py
@@ -1,0 +1,12 @@
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def get_admin_trivia_main_kb():
+    builder = InlineKeyboardBuilder()
+    builder.button(text="❓ Preguntas", callback_data="admin_trivia_questions")
+    builder.button(text="📂 Templates", callback_data="admin_trivia_templates")
+    builder.button(text="📊 Analytics", callback_data="admin_trivia_analytics")
+    builder.button(text="🔴 Trivias Activas", callback_data="admin_trivia_sessions")
+    builder.button(text="🔙 Volver", callback_data="admin_main_menu")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/mybot/states/__init__.py
+++ b/mybot/states/__init__.py
@@ -1,7 +1,9 @@
 from .gamification_states import LorePieceAdminStates
 from .trivia_states import TriviaStates
+from .trivia_admin_states import TriviaAdminStates
 
 __all__ = [
     "LorePieceAdminStates",
     "TriviaStates",
+    "TriviaAdminStates",
 ]

--- a/mybot/states/trivia_admin_states.py
+++ b/mybot/states/trivia_admin_states.py
@@ -1,0 +1,28 @@
+from aiogram.fsm.state import State, StatesGroup
+
+class TriviaAdminStates(StatesGroup):
+    # Estados para gestión de preguntas
+    waiting_question_text = State()
+    waiting_question_type = State()
+    waiting_question_options = State()
+    waiting_correct_answer = State()
+    waiting_explanation = State()
+    waiting_difficulty = State()
+    waiting_time_limit = State()
+    waiting_media_upload = State()
+
+    # Estados para gestión de templates
+    waiting_template_name = State()
+    waiting_template_description = State()
+    waiting_trigger_events = State()
+    waiting_trigger_conditions = State()
+    waiting_reward_config = State()
+    waiting_question_selection = State()
+
+    # Estados para edición
+    editing_question = State()
+    editing_template = State()
+
+    # Estados para vista previa
+    preview_question = State()
+    preview_template = State()


### PR DESCRIPTION
## Summary
- add states for administering trivia
- add keyboard and router for trivia admin panel
- wire trivia admin into admin menu and main keyboard

## Testing
- `python -m py_compile $(git diff --name-only HEAD~1)`

------
https://chatgpt.com/codex/tasks/task_e_6861fa458d688329acd8be53c8c20637