### PR TITLE
Fix trivia import path

### DIFF
--- a/mybot/trivia/analytics.py
+++ b/mybot/trivia/analytics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 from sqlalchemy import select
 
-from ..database.models import UserTriviaHistory, TriviaTemplate
+from database.models import UserTriviaHistory, TriviaTemplate
 
 
 class TriviaAnalytics:


### PR DESCRIPTION
## Summary
- use absolute import for database models in trivia analytics

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6861fad93f9c83299cc933dd134453ec