### PR TITLE
Fix SafeMessagePatch wrapper

### DIFF
--- a/mybot/utils/safe_message_patch.py
+++ b/mybot/utils/safe_message_patch.py
@@ -6,49 +6,60 @@ from aiogram.exceptions import TelegramBadRequest
 class SafeMessagePatch:
     _original_answer = None
     _patched = False
-
+    
     @classmethod
     def apply_patch(cls):
         """Aplica parche global para manejar textos vacíos en message.answer()"""
         if cls._patched:
             return "✅ Parche ya aplicado anteriormente"
-
+        
+        # Guardar método original
         cls._original_answer = Message.answer
-        Message.answer = cls._safe_answer
+        
+        # Crear función wrapper que mantiene la signature correcta
+        async def safe_answer_wrapper(self, text, **kwargs):
+            return await cls._safe_answer_method(self, text, **kwargs)
+        
+        # Reemplazar el método
+        Message.answer = safe_answer_wrapper
         cls._patched = True
-
+        
         logging.info("✅ Parche SafeMessage aplicado - textos vacíos serán manejados automáticamente")
         return "✅ Parche aplicado exitosamente"
-
+    
     @classmethod
-    async def _safe_answer(cls, self, text, **kwargs):
-        """Método seguro que reemplaza message.answer()"""
+    async def _safe_answer_method(cls, message_instance, text, **kwargs):
+        """Método seguro que maneja textos vacíos"""
         try:
             # Validar texto
             if not text or (isinstance(text, str) and text.strip() == ''):
                 # Obtener información del caller
-                frame = inspect.currentframe().f_back
+                frame = inspect.currentframe().f_back.f_back  # Subir dos niveles en el stack
                 frame_info = inspect.getframeinfo(frame)
                 caller_name = frame.f_code.co_name
                 file_name = frame_info.filename.split('/')[-1]
                 line_number = frame_info.lineno
-
+                
                 # Crear mensaje informativo
                 safe_text = f"📝 Texto vacío detectado\n\n🔍 Origen: {caller_name}()\n📁 {file_name}:{line_number}"
-
+                
                 # Log del evento
                 logging.warning(f"Texto vacío parcheado desde: {caller_name}() [{file_name}:{line_number}]")
-
-                return await cls._original_answer(self, safe_text, **kwargs)
-
+                
+                return await cls._original_answer(message_instance, safe_text, **kwargs)
+            
             # Si el texto es válido, usar método original
-            return await cls._original_answer(self, text, **kwargs)
-
+            return await cls._original_answer(message_instance, text, **kwargs)
+            
         except TelegramBadRequest as e:
             if "text must be non-empty" in str(e):
                 # Fallback de emergencia
                 emergency_text = "⚠️ Error: Mensaje sin contenido"
                 logging.error(f"Error Telegram capturado y manejado: {e}")
-                return await cls._original_answer(self, emergency_text, **kwargs)
+                return await cls._original_answer(message_instance, emergency_text, **kwargs)
             raise e
-
+        except Exception as e:
+            # Log de errores inesperados
+            logging.error(f"Error inesperado en parche SafeMessage: {e}")
+            # Intentar con método original
+            return await cls._original_answer(message_instance, text or "⚠️ Error de contenido", **kwargs)


### PR DESCRIPTION
## Summary
- ensure SafeMessagePatch keeps original method signature while handling empty texts
- keep global patch application in `bot.py`

## Testing
- `python -m py_compile mybot/utils/safe_message_patch.py`
- `python -m py_compile mybot/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6862232985b8832991ad58b83da5c35f