### PR TITLE
Update admin main keyboard to reply markup

### DIFF
--- a/mybot/keyboards/admin_main_kb.py
+++ b/mybot/keyboards/admin_main_kb.py
@@ -1,17 +1,11 @@
-from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
 
 def get_admin_main_kb():
-    """Return the main admin inline keyboard with free channel management."""
-    builder = InlineKeyboardBuilder()
-    builder.button(text="📢 Canal VIP", callback_data="admin_vip")
+    """Return the main admin reply keyboard."""
+    keyboard = [
+        [KeyboardButton(text="📊 Estadísticas"), KeyboardButton(text="🛠️ Administrar Trivias")],
+        [KeyboardButton(text="🎒 Mochila Admin"), KeyboardButton(text="⚙️ Configuración")],
+    ]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
 
-    builder.button(text="💬 Canal Free", callback_data="admin_free")
-    builder.button(text="🎮 Juego Kinky", callback_data="admin_kinky_game")
-
-   
-    builder.button(text="🛠 Configuración del Bot", callback_data="admin_config")
-    builder.button(text="📈 Estadísticas", callback_data="admin_stats")
-    builder.button(text="🔙 Volver", callback_data="admin_back")
-    builder.adjust(1)
-    return builder.as_markup()


### PR DESCRIPTION
## Summary
- convert admin main keyboard to a simple reply keyboard with four buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68624eb1f3448329932651e1729e7c9d