### PR TITLE
Ensure create trivia button always answers callback

### DIFF
--- a/mybot/handlers/admin/trivia_admin.py
+++ b/mybot/handlers/admin/trivia_admin.py
@@ -4,6 +4,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from services.trivia_service import TriviaService
 from keyboards.admin_trivia_kb import trivia_admin_main_kb
 from utils.messages import TRIVIA_ADMIN_MENU
+from utils.menu_utils import update_menu
+from keyboards.common import get_back_kb
+from utils.user_roles import is_admin
+import logging
+
+logger = logging.getLogger(__name__)
 
 router = Router()
 
@@ -16,5 +22,28 @@ async def list_trivias(call: CallbackQuery, session: AsyncSession):
     trivias = await TriviaService.get_active_trivias(session)
     text = "\n".join(f"{t.id}. {t.title}" for t in trivias) or "Sin trivias activas."
     await call.message.edit_text(f"📚 *Trivias activas:*\n{text}", parse_mode="Markdown", reply_markup=trivia_admin_main_kb())
+
+
+@router.callback_query(F.data == "create_trivia")
+async def create_trivia_callback(callback: CallbackQuery, session: AsyncSession):
+    """Handle new trivia creation button."""
+    if not is_admin(callback.from_user.id):
+        return await callback.answer()
+
+    await callback.answer("Abriendo menú de creación...")
+
+    try:
+        await update_menu(
+            callback,
+            "🚧 Función de creación de trivias en construcción.",
+            get_back_kb("admin_main_menu"),
+            session,
+            "admin_create_trivia",
+        )
+    except Exception as e:
+        logger.error(f"Error showing trivia creation menu: {e}")
+        await callback.message.answer(
+            "❌ Error al abrir el menú de creación de trivia."
+        )
 
 # Aquí agregas más funciones para crear, editar y eliminar trivias y preguntas.


### PR DESCRIPTION
## Summary
- handle `create_trivia` callback in admin trivia handler
- always answer callback query when creating a new trivia

## Testing
- `python -m py_compile mybot/handlers/admin/trivia_admin.py`

------
https://chatgpt.com/codex/tasks/task_e_6862ba7b3f6c8329856bf39631d816fc