### PR TITLE
Add trivia admin FSM and keyboard

### DIFF
--- a/mybot/handlers/admin/trivia_admin.py
+++ b/mybot/handlers/admin/trivia_admin.py
@@ -1,49 +1,137 @@
 from aiogram import Router, F
 from aiogram.types import Message, CallbackQuery
+from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
 from services.trivia_service import TriviaService
-from keyboards.admin_trivia_kb import trivia_admin_main_kb
-from utils.messages import TRIVIA_ADMIN_MENU
+from keyboards.admin_trivia_kb import (
+    trivia_admin_main_kb,
+    question_type_kb,
+    yes_no_kb,
+    confirm_trivia_kb,
+)
+from states.trivia_states import CreateTrivia
 from utils.menu_utils import update_menu
 from keyboards.common import get_back_kb
-from utils.user_roles import is_admin
 import logging
 
 logger = logging.getLogger(__name__)
-
 router = Router()
+
 
 @router.message(F.text == "🛠️ Administrar Trivias")
 async def admin_trivia_menu(message: Message):
-    await message.answer(TRIVIA_ADMIN_MENU, reply_markup=trivia_admin_main_kb())
+    await message.answer("📚 Menú de administración de Trivias:", reply_markup=trivia_admin_main_kb())
+
 
 @router.callback_query(F.data == "list_trivias")
 async def list_trivias(call: CallbackQuery, session: AsyncSession):
     trivias = await TriviaService.get_active_trivias(session)
     text = "\n".join(f"{t.id}. {t.title}" for t in trivias) or "Sin trivias activas."
-    await call.message.edit_text(f"📚 *Trivias activas:*\n{text}", parse_mode="Markdown", reply_markup=trivia_admin_main_kb())
+    await call.message.edit_text(
+        f"📚 *Trivias activas:*\n{text}", parse_mode="Markdown", reply_markup=trivia_admin_main_kb()
+    )
 
 
 @router.callback_query(F.data == "create_trivia")
-async def create_trivia_callback(callback: CallbackQuery, session: AsyncSession):
-    """Handle new trivia creation button."""
-    if not is_admin(callback.from_user.id):
-        return await callback.answer()
+async def create_trivia(call: CallbackQuery, state: FSMContext):
+    await state.set_state(CreateTrivia.waiting_for_title)
+    await call.message.edit_text("✏️ Envía el título para la nueva trivia:")
 
-    await callback.answer("Abriendo menú de creación...")
 
-    try:
-        await update_menu(
-            callback,
-            "🚧 Función de creación de trivias en construcción.",
-            get_back_kb("admin_main_menu"),
-            session,
-            "admin_create_trivia",
+@router.message(CreateTrivia.waiting_for_title)
+async def trivia_title_received(message: Message, state: FSMContext):
+    await state.update_data(title=message.text, questions=[])
+    await state.set_state(CreateTrivia.waiting_for_total_questions)
+    await message.answer("🔢 ¿Cuántas preguntas tendrá esta trivia? (ej: 5)")
+
+
+@router.message(CreateTrivia.waiting_for_total_questions)
+async def total_questions_received(message: Message, state: FSMContext):
+    if not message.text.isdigit():
+        return await message.answer("⚠️ Ingresa solo números.")
+    await state.update_data(total_questions=int(message.text), current_question=1)
+    await state.set_state(CreateTrivia.waiting_for_question_text)
+    await message.answer("📝 Escribe la primera pregunta:")
+
+
+@router.message(CreateTrivia.waiting_for_question_text)
+async def question_text_received(message: Message, state: FSMContext):
+    await state.update_data(question_text=message.text)
+    await state.set_state(CreateTrivia.waiting_for_question_type)
+    await message.answer("🧐 ¿Qué tipo de pregunta es?", reply_markup=question_type_kb())
+
+
+@router.callback_query(CreateTrivia.waiting_for_question_type)
+async def question_type_received(call: CallbackQuery, state: FSMContext):
+    qtype = call.data
+    await state.update_data(question_type=qtype)
+    if qtype == "open":
+        await state.set_state(CreateTrivia.waiting_for_correct_answer)
+        await call.message.edit_text("✔️ Escribe la respuesta correcta:")
+    else:
+        await state.set_state(CreateTrivia.waiting_for_question_options)
+        await call.message.edit_text("🔠 Envía las opciones separadas por comas (ej: Rojo,Azul,Verde):")
+
+
+@router.message(CreateTrivia.waiting_for_question_options)
+async def options_received(message: Message, state: FSMContext):
+    options = [opt.strip() for opt in message.text.split(",")]
+    await state.update_data(options=options)
+    await state.set_state(CreateTrivia.waiting_for_correct_answer)
+    await message.answer(
+        "✅ Indica cuál es la respuesta correcta exactamente como la escribiste en las opciones:"
+    )
+
+
+@router.message(CreateTrivia.waiting_for_correct_answer)
+async def correct_answer_received(message: Message, state: FSMContext):
+    await state.update_data(correct_answer=message.text)
+    await state.set_state(CreateTrivia.waiting_for_points)
+    await message.answer("💎 ¿Cuántos puntos vale esta pregunta?")
+
+
+@router.message(CreateTrivia.waiting_for_points)
+async def points_received(message: Message, state: FSMContext):
+    if not message.text.isdigit():
+        return await message.answer("⚠️ Ingresa solo números.")
+    await state.update_data(points=int(message.text))
+    await state.set_state(CreateTrivia.waiting_for_unlock_content)
+    await message.answer("🔓 ¿Esta pregunta desbloquea contenido?", reply_markup=yes_no_kb())
+
+
+@router.callback_query(CreateTrivia.waiting_for_unlock_content)
+async def unlock_content_received(call: CallbackQuery, state: FSMContext):
+    unlocks = call.data == "yes"
+    data = await state.get_data()
+    data["questions"].append(
+        {
+            "text": data["question_text"],
+            "type": data["question_type"],
+            "options": data.get("options", []),
+            "answer": data["correct_answer"],
+            "points": data["points"],
+            "unlocks_content": unlocks,
+        }
+    )
+    if data["current_question"] >= data["total_questions"]:
+        await state.update_data(data)
+        await state.set_state(CreateTrivia.confirm_trivia)
+        await call.message.edit_text(
+            "🎯 Trivia lista para guardar. ¿Confirmar creación?", reply_markup=confirm_trivia_kb()
         )
-    except Exception as e:
-        logger.error(f"Error showing trivia creation menu: {e}")
-        await callback.message.answer(
-            "❌ Error al abrir el menú de creación de trivia."
-        )
+    else:
+        data["current_question"] += 1
+        await state.update_data(data, question_text=None, question_type=None, options=None)
+        await state.set_state(CreateTrivia.waiting_for_question_text)
+        await call.message.edit_text(f"📝 Escribe la pregunta #{data['current_question']}:")
 
-# Aquí agregas más funciones para crear, editar y eliminar trivias y preguntas.
+
+@router.callback_query(CreateTrivia.confirm_trivia)
+async def confirm_creation(call: CallbackQuery, state: FSMContext, session: AsyncSession):
+    if call.data == "confirm":
+        data = await state.get_data()
+        await TriviaService.create_trivia(session, data)
+        await call.message.edit_text("✅ Trivia creada exitosamente.")
+    else:
+        await call.message.edit_text("❌ Creación cancelada.")
+    await state.clear()

--- a/mybot/keyboards/admin_trivia_kb.py
+++ b/mybot/keyboards/admin_trivia_kb.py
@@ -1,9 +1,28 @@
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
+
 def trivia_admin_main_kb():
-    buttons = [
+    return InlineKeyboardMarkup(inline_keyboard=[
         [InlineKeyboardButton(text="📖 Listar Trivias", callback_data="list_trivias")],
-        [InlineKeyboardButton(text="✨ Crear Trivia", callback_data="create_trivia")],
-        [InlineKeyboardButton(text="🔙 Volver", callback_data="admin_main_menu")],
-    ]
-    return InlineKeyboardMarkup(inline_keyboard=buttons)
+        [InlineKeyboardButton(text="➕ Crear Nueva Trivia", callback_data="create_trivia")]
+    ])
+
+
+def question_type_kb():
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="📝 Abierta", callback_data="open")],
+        [InlineKeyboardButton(text="🔘 Opciones múltiples", callback_data="multiple")]
+    ])
+
+
+def yes_no_kb():
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="✅ Sí", callback_data="yes"), InlineKeyboardButton(text="❌ No", callback_data="no")]
+    ])
+
+
+def confirm_trivia_kb():
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="✅ Confirmar", callback_data="confirm")],
+        [InlineKeyboardButton(text="❌ Cancelar", callback_data="cancel")]
+    ])

--- a/mybot/services/trivia_service.py
+++ b/mybot/services/trivia_service.py
@@ -39,3 +39,18 @@ class TriviaService:
         attempt.score = total_correct
         attempt.completed_at = datetime.utcnow()
         await session.commit()
+
+    @staticmethod
+    async def create_trivia(session: AsyncSession, data: dict):
+        trivia = Trivia(title=data["title"], is_active=True)
+        session.add(trivia)
+        await session.flush()
+
+        for q in data["questions"]:
+            question = TriviaQuestion(
+                question=q["text"], options=q["options"], correct_option=q["answer"],
+                points=q["points"], exclusive_content=q["unlocks_content"], trivia_id=trivia.id
+            )
+            session.add(question)
+
+        await session.commit()

--- a/mybot/states/trivia_states.py
+++ b/mybot/states/trivia_states.py
@@ -1,0 +1,12 @@
+from aiogram.fsm.state import StatesGroup, State
+
+class CreateTrivia(StatesGroup):
+    waiting_for_title = State()
+    waiting_for_total_questions = State()
+    waiting_for_question_text = State()
+    waiting_for_question_type = State()
+    waiting_for_question_options = State()
+    waiting_for_correct_answer = State()
+    waiting_for_points = State()
+    waiting_for_unlock_content = State()
+    confirm_trivia = State()


### PR DESCRIPTION
## Summary
- implement CreateTrivia FSM
- implement admin trivia handler for creating trivias
- add keyboards for admin trivia workflow
- extend trivia service with create_trivia helper

## Testing
- `python -m py_compile mybot/handlers/admin/trivia_admin.py mybot/keyboards/admin_trivia_kb.py mybot/services/trivia_service.py mybot/states/trivia_states.py`

------
https://chatgpt.com/codex/tasks/task_e_6862befb24bc8329982559841df8c58b