### PR TITLE
Fix /start setup error

### DIFF
--- a/constants/keyboards.py
+++ b/constants/keyboards.py
@@ -1,0 +1,17 @@
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+
+main_menu_keyboard = ReplyKeyboardMarkup(
+    keyboard=[
+        [
+            KeyboardButton(text="🎒 Mochila"),
+            KeyboardButton(text="💰 Billetera"),
+            KeyboardButton(text="🎯 Misiones"),
+        ],
+        [
+            KeyboardButton(text="⚙️ Configuración"),
+            KeyboardButton(text="❓ Ayuda"),
+        ],
+    ],
+    resize_keyboard=True,
+    one_time_keyboard=False,
+)

--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -9,6 +9,7 @@ from aiogram.enums.parse_mode import ParseMode
 from aiogram.client.bot import DefaultBotProperties
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton, ErrorEvent
+from constants.keyboards import main_menu_keyboard
 
 # --- CONFIGURACIÓN DE LOGGING MEJORADA ---
 def setup_logging():
@@ -26,22 +27,7 @@ def setup_logging():
     logging.getLogger('aiogram').setLevel(logging.WARNING)
     logging.getLogger('aiohttp').setLevel(logging.WARNING)
 
-# --- TECLADO PRINCIPAL ---
-main_menu_keyboard = ReplyKeyboardMarkup(
-    keyboard=[
-        [
-            KeyboardButton(text="🎒 Mochila"),
-            KeyboardButton(text="💰 Billetera"),
-            KeyboardButton(text="🎯 Misiones"),
-        ],
-        [
-            KeyboardButton(text="⚙️ Configuración"),
-            KeyboardButton(text="❓ Ayuda"),
-        ],
-    ],
-    resize_keyboard=True,
-    one_time_keyboard=False,
-)
+
 
 # Imports
 from database.setup import init_db, get_session

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -56,7 +56,7 @@ async def admin_start(message: Message, session: AsyncSession):
     if not tenant_status["basic_setup_complete"]:
         # Redirect to setup
         from handlers.setup import start_setup
-        await start_setup(message, session, user_id=message.from_user.id)
+        await start_setup(message, session)
         return
     
     # Show admin panel

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -4,7 +4,7 @@ Enhanced start handler with improved user experience and multi-tenant support.
 from aiogram import Router
 from aiogram.filters import CommandStart
 from aiogram.types import Message
-from constants.keyboards import main_menu_keyboard  # ✅ IMPORTACIÓN CORREGIDA
+from constants.keyboards import main_menu_keyboard
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.models import User


### PR DESCRIPTION
## Summary
- create constant keyboard module
- adjust admin menu setup call
- reference main keyboard from new module
- import keyboard in bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install aiogram==3.5.0`

------
https://chatgpt.com/codex/tasks/task_e_68681dff54e88329bbdc954c08025a1d