### PR TITLE
Fix imports for production

### DIFF
--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -4,7 +4,7 @@ Enhanced start handler with improved user experience and multi-tenant support.
 from aiogram import Router
 from aiogram.filters import CommandStart
 from aiogram.types import Message
-from mybot.constants.keyboards import main_menu_keyboard
+from constants.keyboards import main_menu_keyboard
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.models import User


### PR DESCRIPTION
## Summary
- use relative import in start handler to avoid missing module in production

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68682906578c83299481371388009ac6