### PR TITLE
Fix TriviaStates import in states package

### DIFF
--- a/mybot/states/__init__.py
+++ b/mybot/states/__init__.py
@@ -1,7 +1,8 @@
 from .gamification_states import LorePieceAdminStates
-from .trivia_states import TriviaStates
+
+# TriviaStates lives in services.trivia_states, not in this package.
+# Remove import to avoid ImportError when importing states package.
 
 __all__ = [
     "LorePieceAdminStates",
-    "TriviaStates",
 ]


### PR DESCRIPTION
## Summary
- prevent ImportError by removing TriviaStates import from `mybot/states/__init__.py`

## Testing
- `python -m py_compile mybot/states/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68682c65a6988329bbe536c0a6848702