### PR TITLE
Fix user menu handlers

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -45,6 +45,7 @@ from handlers.missions_handler import router as missions_router
 from handlers.info_handler import router as info_router
 from handlers.free_channel_admin import router as free_channel_admin_router
 from handlers.publication_test import router as publication_test_router
+from handlers.main_menu import router as main_menu_router
 
 import combinar_pistas
 from backpack import router as backpack_router
@@ -195,17 +196,18 @@ async def main() -> None:
             ("auction_admin", auction_admin_router),
             ("start_token", start_token),
             ("start", start.router),
+            ("main_menu", main_menu_router),
             ("backpack", backpack_router),
             ("missions", missions_router),
             ("info", info_router),
             ("free_channel_admin", free_channel_admin_router),
             ("publication_test", publication_test_router),
             ("vip_menu", vip.router),
-            ("gamification", gamification.router),
             ("auction_user", auction_user_router),
             ("reaction_callback", reaction_callback_router),
             ("daily_gift", daily_gift.router),
             ("minigames", minigames.router),
+            ("gamification", gamification.router),
             ("free_user", free_user.router),
             ("lore", lore_router),
             ("combinar_pistas", combinar_pistas.router),

--- a/mybot/handlers/main_menu.py
+++ b/mybot/handlers/main_menu.py
@@ -1,0 +1,28 @@
+from aiogram import Router, F
+from aiogram.types import Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = Router()
+
+@router.message(F.text == "🎒 Mochila")
+async def handle_backpack_button(message: Message, session: AsyncSession):
+    from backpack import mostrar_mochila_narrativa
+    await mostrar_mochila_narrativa(message)
+
+@router.message(F.text == "💰 Billetera")
+async def handle_wallet_button(message: Message, session: AsyncSession):
+    await message.answer("💰 **Tu Billetera**\n\nFuncionalidad en desarrollo...")
+
+@router.message(F.text == "🎯 Misiones")
+async def handle_missions_button(message: Message, session: AsyncSession):
+    from handlers.missions_handler import show_available_missions
+    fake_callback = type("cb", (), {"from_user": message.from_user, "data": "misiones_disponibles", "message": message})
+    await show_available_missions(fake_callback, session)
+
+@router.message(F.text == "⚙️ Configuración")
+async def handle_config_button(message: Message, session: AsyncSession):
+    await message.answer("⚙️ **Configuración**\n\nOpciones de usuario...")
+
+@router.message(F.text == "❓ Ayuda")
+async def handle_help_button(message: Message, session: AsyncSession):
+    await message.answer("❓ **Ayuda**\n\nGuía de uso del bot...")

--- a/mybot/utils/messages.py
+++ b/mybot/utils/messages.py
@@ -171,6 +171,12 @@ MISSION_MESSAGES = {
     "weekly_ranking_title": "🏅 Ranking Semanal de Reacciones",
     "weekly_ranking_entry": "#{rank}. @{username} - {count} reacciones",
     "challenge_started": "Reto iniciado! Reacciona a {count} publicaciones para ganar puntos.",
+    "mission_details_text": (
+        "🎯 *{mission_name}*\n"
+        "{mission_description}\n\n"
+        "🏆 Recompensa: {points_reward} puntos\n"
+        "🗂 Tipo: {mission_type}"
+    ),
     "view_all_missions_button_text": "📋 Ver Todas las Misiones",
 }
 


### PR DESCRIPTION
## Summary
- add mission details text template
- connect main menu buttons for normal users
- register the main menu router and reorder routers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68682ee2d59483299c5c36bad294c6d6