### PR TITLE
Implement debug middleware for normal users

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -60,6 +60,7 @@ from services.scheduler import auction_monitor_scheduler, free_channel_cleanup_s
 
 # Middlewares
 from middlewares import PointsMiddleware, UserRegistrationMiddleware
+from middlewares.debug_middleware import DebugMiddleware
 
 # --- MANEJO DE ERRORES GLOBAL ---
 async def global_error_handler(event: ErrorEvent) -> None:
@@ -154,10 +155,14 @@ async def main() -> None:
 
         # Configuración del bot
         bot = Bot(
-            BOT_TOKEN, 
+            BOT_TOKEN,
             default=DefaultBotProperties(parse_mode=ParseMode.HTML)
         )
         dp = Dispatcher(storage=MemoryStorage())
+
+        # Debug middleware para usuarios normales
+        dp.message.outer_middleware(DebugMiddleware())
+        dp.callback_query.outer_middleware(DebugMiddleware())
 
         # Registrar manejo de errores PRIMERO
         dp.error.register(global_error_handler)
@@ -191,11 +196,11 @@ async def main() -> None:
         # Registrar routers en orden de prioridad
         logger.info("Registrando handlers...")
         routers = [
+            ("start", start.router),
             ("setup", setup_handlers.router),
             ("admin", admin_router),
             ("auction_admin", auction_admin_router),
             ("start_token", start_token),
-            ("start", start.router),
             ("main_menu", main_menu_router),
             ("backpack", backpack_router),
             ("missions", missions_router),

--- a/mybot/handlers/start.py
+++ b/mybot/handlers/start.py
@@ -156,3 +156,10 @@ async def cmd_start(message: Message, session: AsyncSession):
             "❌ **Error del Sistema**\n\n"
             "Ocurrió un error inesperado. El equipo técnico ha sido notificado."
         )
+
+
+@router.message()
+async def debug_unhandled_message(message: Message):
+    """Captura mensajes no manejados para debugging"""
+    logger.warning(f"\N{magnifying glass tilted left} UNHANDLED MESSAGE from {message.from_user.id}: {message.text}")
+    # Solo registrar, sin responder

--- a/mybot/middlewares/__init__.py
+++ b/mybot/middlewares/__init__.py
@@ -1,7 +1,9 @@
 from .points_middleware import PointsMiddleware
 from .user_middleware import UserRegistrationMiddleware
+from .debug_middleware import DebugMiddleware
 
 __all__ = [
     "PointsMiddleware",
     "UserRegistrationMiddleware",
+    "DebugMiddleware",
 ]

--- a/mybot/middlewares/debug_middleware.py
+++ b/mybot/middlewares/debug_middleware.py
@@ -1,0 +1,54 @@
+import logging
+from aiogram import BaseMiddleware
+from aiogram.types import TelegramObject, Message, CallbackQuery
+from typing import Callable, Dict, Any, Awaitable
+
+logger = logging.getLogger(__name__)
+
+class DebugMiddleware(BaseMiddleware):
+    """Middleware para debugging detallado de usuarios normales"""
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, Dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: Dict[str, Any]
+    ) -> Any:
+        user_id = None
+        event_type = type(event).__name__
+
+        if hasattr(event, 'from_user') and event.from_user:
+            user_id = event.from_user.id
+
+        if user_id and user_id != 1280444712:  # Reemplazar con tu admin ID
+            if isinstance(event, Message):
+                logger.info(f"\N{magnifying glass tilted left} DEBUG USER {user_id}: Message received")
+                logger.info(f"   Text: {event.text}")
+                logger.info(f"   Command: {event.text.startswith('/') if event.text else False}")
+                logger.info(
+                    f"   Handler chain: {handler.__name__ if hasattr(handler, '__name__') else 'Unknown'}"
+                )
+
+            elif isinstance(event, CallbackQuery):
+                logger.info(f"\N{magnifying glass tilted left} DEBUG USER {user_id}: Callback received")
+                logger.info(f"   Data: {event.data}")
+                logger.info(
+                    f"   Handler chain: {handler.__name__ if hasattr(handler, '__name__') else 'Unknown'}"
+                )
+
+        try:
+            result = await handler(event, data)
+            if user_id and user_id != 1280444712:
+                logger.info(f"\N{check mark} DEBUG USER {user_id}: Handler executed successfully")
+            return result
+
+        except Exception as e:
+            if user_id and user_id != 1280444712:
+                logger.error(f"\N{cross mark} DEBUG USER {user_id}: Handler failed")
+                logger.error(f"   Error: {type(e).__name__}: {e}")
+                logger.error(f"   Event: {event_type}")
+                if isinstance(event, Message) and event.text:
+                    logger.error(f"   Text: {event.text}")
+                elif isinstance(event, CallbackQuery):
+                    logger.error(f"   Callback: {event.data}")
+            raise


### PR DESCRIPTION
## Summary
- add detailed DebugMiddleware
- register debug middleware early in the dispatcher
- reorder routers so `start` router is first
- expose DebugMiddleware in middleware package
- log unhandled messages for debugging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868319e17a883298db94d14cfc5aa18