### PR TITLE
Fix relative imports for production use

### DIFF
--- a/mybot/backpack.py
+++ b/mybot/backpack.py
@@ -5,7 +5,7 @@ from aiogram.types import Message, CallbackQuery, InlineKeyboardButton, InlineKe
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from sqlalchemy import select, and_, func
-from .database.narrative_models import LorePiece, UserLorePiece
+from database.narrative_models import LorePiece, UserLorePiece
 from database.hint_combination import HintCombination
 from database.setup import get_session
 from notificaciones import send_narrative_notification

--- a/mybot/combinar_pistas.py
+++ b/mybot/combinar_pistas.py
@@ -6,7 +6,7 @@ from aiogram.fsm.state import StatesGroup, State
 from aiogram.filters import Command
 from sqlalchemy.future import select
 from database.setup import get_session
-from .database.narrative_models import UserLorePiece, LorePiece
+from database.narrative_models import UserLorePiece, LorePiece
 from database.hint_combination import HintCombination
 from narrativa import desbloquear_pista
 

--- a/mybot/database/setup.py
+++ b/mybot/database/setup.py
@@ -1,7 +1,7 @@
 # database/setup.py
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.pool import NullPool # NullPool es adecuado para Railway, para SQLite local puedes mantenerlo o quitarlo
-from .models import Base
+from models import Base
 from utils.config import Config
 
 # Hacemos que el motor sea una variable global o pasada, no creada repetidamente

--- a/mybot/handlers/admin/__init__.py
+++ b/mybot/handlers/admin/__init__.py
@@ -1,13 +1,13 @@
-from .admin_menu import router as admin_router
-from .vip_menu import router as vip_router
-from .free_menu import router as free_router
-from .config_menu import router as config_router
-from .channel_admin import router as channel_admin_router
-from .subscription_plans import router as subscription_plans_router
-from .game_admin import router as game_admin_router
-from .event_admin import router as event_admin_router
-from .admin_config import router as admin_config_router
-from .trivia_admin import router as trivia_admin_router
+from admin_menu import router as admin_router
+from vip_menu import router as vip_router
+from free_menu import router as free_router
+from config_menu import router as config_router
+from channel_admin import router as channel_admin_router
+from subscription_plans import router as subscription_plans_router
+from game_admin import router as game_admin_router
+from event_admin import router as event_admin_router
+from admin_config import router as admin_config_router
+from trivia_admin import router as trivia_admin_router
 
 # Asegúrate de incluir trivia_admin_router al registrar routers:
 admin_router.include_router(trivia_admin_router)

--- a/mybot/handlers/admin/admin_menu.py
+++ b/mybot/handlers/admin/admin_menu.py
@@ -28,14 +28,14 @@ logger = logging.getLogger(__name__)
 router = Router()
 
 # Include all sub-routers
-from .vip_menu import router as vip_router
-from .free_menu import router as free_router
-from .config_menu import router as config_router
-from .channel_admin import router as channel_admin_router
-from .subscription_plans import router as subscription_plans_router
-from .game_admin import router as game_admin_router
-from .event_admin import router as event_admin_router
-from .admin_config import router as admin_config_router
+from vip_menu import router as vip_router
+from free_menu import router as free_router
+from config_menu import router as config_router
+from channel_admin import router as channel_admin_router
+from subscription_plans import router as subscription_plans_router
+from game_admin import router as game_admin_router
+from event_admin import router as event_admin_router
+from admin_config import router as admin_config_router
 
 router.include_router(vip_router)
 router.include_router(free_router)

--- a/mybot/handlers/admin/game_admin.py
+++ b/mybot/handlers/admin/game_admin.py
@@ -34,8 +34,8 @@ from utils.admin_state import (
 from services.mission_service import MissionService
 from services.reward_service import RewardService
 from services.level_service import LevelService
-from ...database.models import User, Mission
-from ...database.narrative_models import LorePiece
+from database.models import User, Mission
+from database.narrative_models import LorePiece
 from services.lore_piece_service import LorePieceService
 from services.point_service import PointService
 from services.config_service import ConfigService

--- a/mybot/handlers/lore_handlers.py
+++ b/mybot/handlers/lore_handlers.py
@@ -12,7 +12,7 @@ from aiogram.types import (
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
-from ..database.narrative_models import LorePiece, UserLorePiece
+from database.narrative_models import LorePiece, UserLorePiece
 
 
 logger = logging.getLogger(__name__)

--- a/mybot/handlers/user/__init__.py
+++ b/mybot/handlers/user/__init__.py
@@ -1,3 +1,3 @@
-from .start_token import router as start_token
+from start_token import router as start_token
 
 __all__ = ["start_token"]

--- a/mybot/middlewares/__init__.py
+++ b/mybot/middlewares/__init__.py
@@ -1,5 +1,5 @@
-from .points_middleware import PointsMiddleware
-from .user_middleware import UserRegistrationMiddleware
+from points_middleware import PointsMiddleware
+from user_middleware import UserRegistrationMiddleware
 
 __all__ = [
     "PointsMiddleware",

--- a/mybot/mochila.py
+++ b/mybot/mochila.py
@@ -1,7 +1,7 @@
 from aiogram import Router, F
 from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
 from sqlalchemy.future import select
-from .database.narrative_models import UserLorePiece, LorePiece
+from database.narrative_models import UserLorePiece, LorePiece
 from database.setup import get_session
 
 router = Router()

--- a/mybot/narrativa.py
+++ b/mybot/narrativa.py
@@ -1,6 +1,6 @@
 from aiogram import Bot
 from sqlalchemy.future import select
-from .database.narrative_models import UserLorePiece, LorePiece
+from database.narrative_models import UserLorePiece, LorePiece
 from database.setup import get_session
 
 async def desbloquear_pista(bot: Bot, user_id: int, pista_code: str):

--- a/mybot/services/__init__.py
+++ b/mybot/services/__init__.py
@@ -1,21 +1,21 @@
-from .achievement_service import AchievementService
-from .badge_service import BadgeService
-from .level_service import LevelService
-from .mission_service import MissionService
-from .point_service import PointService
-from .reward_service import RewardService
-from .subscription_service import SubscriptionService, get_admin_statistics
-from .token_service import TokenService, validate_token
-from .config_service import ConfigService
-from .plan_service import SubscriptionPlanService
-from .channel_service import ChannelService
-from .event_service import EventService
-from .raffle_service import RaffleService
-from .message_service import MessageService
-from .auction_service import AuctionService
-from .user_service import UserService
-from .lore_piece_service import LorePieceService
-from .scheduler import channel_request_scheduler, vip_subscription_scheduler, vip_membership_scheduler
+from achievement_service import AchievementService
+from badge_service import BadgeService
+from level_service import LevelService
+from mission_service import MissionService
+from point_service import PointService
+from reward_service import RewardService
+from subscription_service import SubscriptionService, get_admin_statistics
+from token_service import TokenService, validate_token
+from config_service import ConfigService
+from plan_service import SubscriptionPlanService
+from channel_service import ChannelService
+from event_service import EventService
+from raffle_service import RaffleService
+from message_service import MessageService
+from auction_service import AuctionService
+from user_service import UserService
+from lore_piece_service import LorePieceService
+from scheduler import channel_request_scheduler, vip_subscription_scheduler, vip_membership_scheduler
 
 __all__ = [
     "AchievementService",

--- a/mybot/services/daily_gift_service.py
+++ b/mybot/services/daily_gift_service.py
@@ -2,8 +2,8 @@ import datetime
 from aiogram import Bot
 from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import UserStats
-from .point_service import PointService
-from .config_service import ConfigService
+from point_service import PointService
+from config_service import ConfigService
 
 class DailyGiftService:
     def __init__(self, session: AsyncSession):

--- a/mybot/services/message_service.py
+++ b/mybot/services/message_service.py
@@ -12,8 +12,8 @@ from sqlalchemy import select, func
 import datetime
 import logging
 
-from .config_service import ConfigService
-from .channel_service import ChannelService
+from config_service import ConfigService
+from channel_service import ChannelService
 from database.models import ButtonReaction
 from keyboards.inline_post_kb import get_reaction_kb
 from services.message_registry import store_message

--- a/mybot/services/minigame_service.py
+++ b/mybot/services/minigame_service.py
@@ -2,8 +2,8 @@ import datetime
 from aiogram import Bot
 from sqlalchemy.ext.asyncio import AsyncSession
 from database.models import UserStats, MiniGamePlay, Mission, UserMissionEntry
-from .point_service import PointService
-from .mission_service import MissionService
+from point_service import PointService
+from mission_service import MissionService
 
 class MiniGameService:
     def __init__(self, session: AsyncSession):

--- a/mybot/states/__init__.py
+++ b/mybot/states/__init__.py
@@ -1,4 +1,4 @@
-from .gamification_states import LorePieceAdminStates
+from gamification_states import LorePieceAdminStates
 
 # TriviaStates lives in services.trivia_states, not in this package.
 # Remove import to avoid ImportError when importing states package.

--- a/mybot/utils/text_utils.py
+++ b/mybot/utils/text_utils.py
@@ -1,5 +1,5 @@
 import re
-from .config import ADMIN_IDS
+from config import ADMIN_IDS
 
 
 def sanitize_text(value: str | None) -> str | None:

--- a/mybot/utils/user_roles.py
+++ b/mybot/utils/user_roles.py
@@ -1,7 +1,7 @@
 from aiogram import Bot
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-from .config import ADMIN_IDS, VIP_CHANNEL_ID
+from config import ADMIN_IDS, VIP_CHANNEL_ID
 from database.models import User, VipSubscription
 import os
 import time


### PR DESCRIPTION
## Summary
- update modules to use absolute imports instead of relative ones

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: dialogue_manager.py syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_686ad98bead4832993101475e8084a1d