### PR TITLE
Fix DialogueHistory import

### DIFF
--- a/mybot/handlers/narrative/enhanced_backpack.py
+++ b/mybot/handlers/narrative/enhanced_backpack.py
@@ -11,8 +11,8 @@ from sqlalchemy import select, and_
 from typing import List, Optional, Tuple
 
 from database.narrative_models import (
-    LorePiece, UserLorePiece, UnsentLetter, 
-    UserUnsentLetter, DialogueMemory
+    LorePiece, UserLorePiece, UnsentLetter,
+    UserUnsentLetter, DialogueHistory
 )
 from database.models import User
 


### PR DESCRIPTION
## Summary
- update narrative import to use `DialogueHistory`

## Testing
- `grep -n "DialogueHistory" -n mybot/handlers/narrative/enhanced_backpack.py`


------
https://chatgpt.com/codex/tasks/task_e_686af290201c832997583ed4a83cd5fc