### PR TITLE
Fix typing imports in enhanced backpack

### DIFF
--- a/mybot/handlers/narrative/enhanced_backpack.py
+++ b/mybot/handlers/narrative/enhanced_backpack.py
@@ -8,7 +8,7 @@ from aiogram import Router, types, F
 from aiogram.filters import Command
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, and_
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from database.narrative_models import (
     LorePiece, UserLorePiece, UnsentLetter,


### PR DESCRIPTION
## Summary
- include `Dict` in `from typing` import for the `enhanced_backpack` handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_686af3bcfa4c8329828650000360e6be