### PR TITLE
Add ephem and disable narrative events

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -71,7 +71,7 @@ from handlers.narrative import (
     narrative_missions,
     enhanced_backpack
 )
-from services.narrative.narrative_events import narrative_event_scheduler
+# from services.narrative.narrative_events import narrative_event_scheduler
 from middlewares.narrative_middleware import NarrativeContextMiddleware
 
 # --- MANEJO DE ERRORES GLOBAL ---
@@ -264,10 +264,10 @@ async def main() -> None:
             "channel_cleanup"
         )
 
-        task_manager.add_task(
-            narrative_event_scheduler(bot, Session),
-            "narrative_events"
-        )
+        # task_manager.add_task(
+        #     narrative_event_scheduler(bot, Session),
+        #     "narrative_events"
+        # )
 
         # Iniciar polling
         logger.info("Bot iniciado correctamente. Comenzando polling...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 -r mybot/requirements.txt
+ephem==4.1.4


### PR DESCRIPTION
## Summary
- add `ephem` dependency
- temporarily disable narrative event scheduler in `bot.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_e_686af5bac5908329b481a23978eca24a