### PR TITLE
Add initial narrative system models and handlers

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -46,6 +46,7 @@ from handlers.info_handler import router as info_router
 from handlers.free_channel_admin import router as free_channel_admin_router
 from handlers.publication_test import router as publication_test_router
 from handlers.main_menu import router as main_menu_router
+from handlers.narrative import diana_dialogue_router
 
 import combinar_pistas
 from backpack import router as backpack_router
@@ -225,6 +226,7 @@ async def main() -> None:
             ("free_user", free_user.router),
             ("lore", lore_router),
             ("combinar_pistas", combinar_pistas.router),
+            ("diana_dialogue", diana_dialogue_router),
             ("channel_access", channel_access_router),
         ]
         

--- a/mybot/database/models.py
+++ b/mybot/database/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     UniqueConstraint,
     Enum,
 )
+from sqlalchemy.orm import relationship
 from uuid import uuid4
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.sql import func
@@ -55,6 +56,10 @@ class User(AsyncAttrs, Base):
     menu_state = Column(
         String, default="root"
     )  # e.g., "root", "profile", "missions", "rewards"
+
+    narrative_state = relationship(
+        "NarrativeState", back_populates="user", uselist=False
+    )
 
 
 

--- a/mybot/database/narrative_models.py
+++ b/mybot/database/narrative_models.py
@@ -1,0 +1,106 @@
+# mybot/database/narrative_models.py
+from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, Text, JSON, ForeignKey, BigInteger, Enum
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from enum import Enum as PyEnum
+
+from database.setup import Base
+
+# Enums para el sistema narrativo
+class RelationshipStage(PyEnum):
+    STRANGER = "stranger"
+    CURIOUS = "curious"
+    ACQUAINTANCE = "acquaintance"
+    TRUSTED = "trusted"
+    CONFIDANT = "confidant"
+    INTIMATE = "intimate"
+
+class EmotionalState(PyEnum):
+    NEUTRAL = "neutral"
+    INTRIGUED = "intrigued"
+    PLAYFUL = "playful"
+    VULNERABLE = "vulnerable"
+    DEFENSIVE = "defensive"
+    WARM = "warm"
+    MYSTERIOUS = "mysterious"
+    INTENSE = "intense"
+    NOSTALGIC = "nostalgic"
+    HOPEFUL = "hopeful"
+
+class UserArchetype(PyEnum):
+    UNKNOWN = "unknown"
+    ROMANTIC = "romantic"
+    DIRECT = "direct"
+    ANALYTICAL = "analytical"
+    EXPLORER = "explorer"
+    PATIENT = "patient"
+    PERSISTENT = "persistent"
+
+# Modelo principal de estado narrativo
+class NarrativeState(Base):
+    """Estado narrativo del usuario con Diana"""
+    __tablename__ = "narrative_states"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(BigInteger, ForeignKey("users.id"), unique=True, nullable=False)
+
+    # Nivel narrativo actual (0-6)
+    narrative_level = Column(Integer, default=0)
+    current_chapter = Column(String, default="prologue")
+
+    # Métricas de relación
+    trust_level = Column(Float, default=0.0)  # 0.0 a 1.0
+    vulnerability_shown = Column(Float, default=0.0)  # 0.0 a 1.0
+    mystery_remaining = Column(Float, default=1.0)  # 1.0 a 0.0
+    emotional_connection = Column(Float, default=0.0)  # 0.0 a 1.0
+
+    # Contadores de interacción
+    total_interactions = Column(Integer, default=0)
+    meaningful_conversations = Column(Integer, default=0)
+    secrets_revealed = Column(Integer, default=0)
+    vulnerable_moments = Column(Integer, default=0)
+
+    # Estados y flags
+    relationship_stage = Column(Enum(RelationshipStage), default=RelationshipStage.STRANGER)
+    current_emotional_state = Column(Enum(EmotionalState), default=EmotionalState.NEUTRAL)
+    user_archetype = Column(Enum(UserArchetype), default=UserArchetype.UNKNOWN)
+
+    # Timestamps importantes
+    first_interaction = Column(DateTime, default=datetime.utcnow)
+    last_meaningful_interaction = Column(DateTime)
+    last_vulnerability_shown = Column(DateTime)
+
+    # Relaciones
+    user = relationship("User", back_populates="narrative_state", uselist=False)
+
+# Piezas de lore
+class LorePiece(Base):
+    """Piezas de historia/lore que los usuarios pueden descubrir"""
+    __tablename__ = "lore_pieces"
+
+    id = Column(Integer, primary_key=True)
+    code_name = Column(String, unique=True, nullable=False)
+    title = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+    piece_type = Column(String, nullable=False)  # "diary", "memory", "artifact", "letter"
+
+    # Condiciones de desbloqueo
+    required_level = Column(Integer, default=0)
+    required_trust = Column(Float, default=0.0)
+
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+class UserLorePiece(Base):
+    """Relación entre usuarios y las piezas de lore que han encontrado"""
+    __tablename__ = "user_lore_pieces"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(BigInteger, ForeignKey("users.id"), nullable=False)
+    lore_piece_id = Column(Integer, ForeignKey("lore_pieces.id"), nullable=False)
+
+    found_at = Column(DateTime, default=datetime.utcnow)
+
+    # Relaciones
+    user = relationship("User", backref="found_lore_pieces")
+    lore_piece = relationship("LorePiece")
+

--- a/mybot/handlers/narrative/__init__.py
+++ b/mybot/handlers/narrative/__init__.py
@@ -1,0 +1,5 @@
+# mybot/handlers/narrative/__init__.py
+from .diana_dialogue import router as diana_dialogue_router
+
+__all__ = ['diana_dialogue_router']
+

--- a/mybot/handlers/narrative/diana_dialogue.py
+++ b/mybot/handlers/narrative/diana_dialogue.py
@@ -1,0 +1,45 @@
+# mybot/handlers/narrative/diana_dialogue.py
+from aiogram import Router, F
+from aiogram.types import Message, CallbackQuery
+from aiogram.filters import Command
+import logging
+
+from services.narrative_service import NarrativeService
+
+router = Router(name="diana_dialogue")
+logger = logging.getLogger(__name__)
+
+@router.message(Command("diana"))
+async def start_diana_dialogue(message: Message, session, bot):
+    """Comando para iniciar diálogo con Diana"""
+    user_id = message.from_user.id
+
+    # Obtener estado narrativo
+    narrative_state = await NarrativeService.get_or_create_narrative_state(session, user_id)
+
+    # Respuesta basada en el nivel de relación
+    if narrative_state.relationship_stage.value == "stranger":
+        response = "Oh... no esperaba compañía. ¿Quién eres?"
+    elif narrative_state.relationship_stage.value == "curious":
+        response = "Ah, eres tú otra vez... Interesante."
+    else:
+        response = f"Hola de nuevo... (Confianza: {narrative_state.trust_level:.1%})"
+
+    await message.answer(response)
+
+    # Actualizar interacciones
+    narrative_state.total_interactions += 1
+    await session.commit()
+
+@router.message(F.text & F.reply_to_message)
+async def diana_response(message: Message, session, bot):
+    """Responde a mensajes cuando Diana está activa"""
+    # Por ahora, solo registramos la interacción
+    if message.reply_to_message.from_user.id == bot.id:
+        user_id = message.from_user.id
+
+        # Actualizar confianza ligeramente
+        await NarrativeService.update_trust_level(session, user_id, 0.01)
+
+        await message.answer("*Diana te observa con curiosidad*")
+

--- a/mybot/services/narrative_service.py
+++ b/mybot/services/narrative_service.py
@@ -1,0 +1,51 @@
+# mybot/services/narrative_service.py
+import logging
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from database.models import User
+from database.narrative_models import NarrativeState, RelationshipStage, EmotionalState
+
+logger = logging.getLogger(__name__)
+
+class NarrativeService:
+    """Servicio para gestionar el estado narrativo de los usuarios"""
+
+    @staticmethod
+    async def get_or_create_narrative_state(session: AsyncSession, user_id: int) -> NarrativeState:
+        """Obtiene o crea el estado narrativo de un usuario"""
+        result = await session.execute(
+            select(NarrativeState).where(NarrativeState.user_id == user_id)
+        )
+        narrative_state = result.scalar_one_or_none()
+
+        if not narrative_state:
+            narrative_state = NarrativeState(user_id=user_id)
+            session.add(narrative_state)
+            await session.commit()
+            logger.info(f"Created narrative state for user {user_id}")
+
+        return narrative_state
+
+    @staticmethod
+    async def update_trust_level(session: AsyncSession, user_id: int, delta: float):
+        """Actualiza el nivel de confianza"""
+        narrative_state = await NarrativeService.get_or_create_narrative_state(session, user_id)
+
+        narrative_state.trust_level = max(0.0, min(1.0, narrative_state.trust_level + delta))
+        narrative_state.total_interactions += 1
+
+        # Actualizar stage basado en trust
+        if narrative_state.trust_level >= 0.8:
+            narrative_state.relationship_stage = RelationshipStage.INTIMATE
+        elif narrative_state.trust_level >= 0.6:
+            narrative_state.relationship_stage = RelationshipStage.CONFIDANT
+        elif narrative_state.trust_level >= 0.4:
+            narrative_state.relationship_stage = RelationshipStage.TRUSTED
+        elif narrative_state.trust_level >= 0.2:
+            narrative_state.relationship_stage = RelationshipStage.ACQUAINTANCE
+        elif narrative_state.trust_level >= 0.1:
+            narrative_state.relationship_stage = RelationshipStage.CURIOUS
+
+        await session.commit()
+        logger.info(f"Updated trust level for user {user_id}: {narrative_state.trust_level}")
+


### PR DESCRIPTION
## Summary
- implement new narrative database models
- create narrative service for managing user narrative state
- add handler for Diana dialogue and expose router
- register narrative router in bot
- link User model with NarrativeState

## Testing
- `python -m py_compile mybot/database/narrative_models.py mybot/services/narrative_service.py mybot/handlers/narrative/diana_dialogue.py mybot/handlers/narrative/__init__.py mybot/database/models.py mybot/bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686b090e93c8832991de26b9dad26d2b